### PR TITLE
Added a method to check if a control has event handlers for a particular event combination

### DIFF
--- a/BlocksKit/UIControl+BlocksKit.h
+++ b/BlocksKit/UIControl+BlocksKit.h
@@ -34,4 +34,11 @@
  */
 - (void)removeEventHandlersForControlEvents:(UIControlEvents)controlEvents;
 
+/** Checks to see if the control has any blocks for a particular event combination.
+ @param controlEvents A bitmask specifying the control events for which to check for blocks.
+ @see addEventHandler:forControlEvents:
+ @return Returns YES if there are blocks for these control events, NO otherwise.
+ */
+- (BOOL)hasEventHandlersForControlEvents:(UIControlEvents)controlEvents;
+
 @end

--- a/BlocksKit/UIControl+BlocksKit.m
+++ b/BlocksKit/UIControl+BlocksKit.m
@@ -80,4 +80,19 @@ static char *kControlBlockArrayKey = "UIControlBlockHandlerArray";
     [actions removeObjectsInArray:forControlEvent];
 }
 
+- (BOOL)hasEventHandlersForControlEvents:(UIControlEvents)controlEvents {
+    NSMutableArray *actions = [self associatedValueForKey:&kControlBlockArrayKey];
+    
+    if (!actions)
+        return NO;
+    
+    for (BKControlWrapper *wrapper in actions) {
+        if ([wrapper controlEvents] == controlEvents) {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
 @end


### PR DESCRIPTION
I needed this because in one scenario in my app I was adding the same event handler multiple times for the same control.

I know I can remove them before adding them, but I found this convenience method more useful.
