### PR TITLE
setResponseLength has wrong associated key

### DIFF
--- a/BlocksKit/NSURLConnection+BlocksKit.m
+++ b/BlocksKit/NSURLConnection+BlocksKit.m
@@ -227,7 +227,7 @@ static char *kDownloadProgressHandlerKey = "NSURLConnectionDownload";
         return;
     
     NSNumber *value = [NSNumber numberWithUnsignedInteger:responseLength];
-    return [self associateValue:value withKey:kResponseKey];
+    return [self associateValue:value withKey:kResponseLengthKey];
 }
 
 #pragma mark Properties


### PR DESCRIPTION
didFinishLoadingHandler block NSURLResponse is a NSNumber instead of being a NSURLResponse due to the fact that setResponseLength has the wrong associated key: kResponseKey (instead of) kResponseLengthKey

Thanks
Anthony
