### PR TITLE
Add missing #import "BKGlobals.h"

### DIFF
--- a/BlocksKit/NSCache+BlocksKit.h
+++ b/BlocksKit/NSCache+BlocksKit.h
@@ -1,3 +1,5 @@
+#import "BKGlobals.h"
+
 //
 //  NSCache+BlocksKit.h
 //  %PROJECT


### PR DESCRIPTION
This change also makes #import "BlocksKit.h" in the .pch preserve Xcode's syntax highlighting.
