### PR TITLE
Add missing BKGlobals.h imports.

### DIFF
--- a/BlocksKit/MFMailComposeViewController+BlocksKit.h
+++ b/BlocksKit/MFMailComposeViewController+BlocksKit.h
@@ -3,6 +3,8 @@
 //  %PROJECT
 //
 
+#import "BKGlobals.h"
+
 typedef void (^BKMailComposeBlock) (MFMailComposeResult result, NSError *error);
 
 /** MFMailComposeViewController with block callbacks.

--- a/BlocksKit/MFMessageComposeViewController+BlocksKit.h
+++ b/BlocksKit/MFMessageComposeViewController+BlocksKit.h
@@ -3,6 +3,8 @@
 //  %PROJECT
 //
 
+#import "BKGlobals.h"
+
 typedef void (^BKMessageComposeBlock) (MessageComposeResult result);
 
 /** MFMessageComposeViewController with block callback in addition to delegation.


### PR DESCRIPTION
In BlocksKit/MFMailComposeViewController+BlocksKit.h and BlocksKit/MFMessageComposeViewController+BlocksKit.h the BKGlobals.h wasn't imported, which resulted in a compile error for me.
