### PR TITLE
Copy-autorelease block IMPs

### DIFF
--- a/BlocksKit/A2BlockDelegate+BlocksKit.m
+++ b/BlocksKit/A2BlockDelegate+BlocksKit.m
@@ -93,7 +93,7 @@ static void bk_lazySwizzle(void) __attribute__((constructor));
 			
 			if (&imp_implementationWithBlock)
 			{
-				implementation = imp_implementationWithBlock(^(NSObject *obj, id block) {
+				implementation = imp_implementationWithBlock([[^(NSObject *obj, id block) {
 					A2DynamicDelegate *dynamicDelegate = [obj dynamicDelegateForProtocol: protocol];
 					[dynamicDelegate implementMethod: representedSelector withBlock: block];
 					
@@ -115,7 +115,7 @@ static void bk_lazySwizzle(void) __attribute__((constructor));
 						if (![originalDelegate isKindOfClass:[A2DynamicDelegate class]])
 							[obj performSelector:a2_setter withObject:dynamicDelegate];
 					}
-				});
+				} copy] autorelease]);
 			}
 			else
 			{
@@ -184,7 +184,7 @@ static void bk_lazySwizzle(void) __attribute__((constructor));
 	
 	if (&imp_implementationWithBlock)
 	{
-		setterImplementation = imp_implementationWithBlock((__bridge void *) ^(NSObject *self, id delegate) {
+		setterImplementation = imp_implementationWithBlock((__bridge void *) [[^(NSObject *self, id delegate) {
 			A2DynamicDelegate *dynamicDelegate = [self dynamicDelegateForProtocol: protocol];
 			
 			if ([self respondsToSelector:a2_setter]) {
@@ -195,12 +195,12 @@ static void bk_lazySwizzle(void) __attribute__((constructor));
 			
 			if ([delegate isEqual: self] || [delegate isEqual: dynamicDelegate]) delegate = nil;
 			dynamicDelegate.realDelegate = delegate;
-		});
+		} copy] autorelease]);
 		
-		getterImplementation = imp_implementationWithBlock((__bridge void *) ^id(NSObject *self) {
+		getterImplementation = imp_implementationWithBlock((__bridge void *) [[^id(NSObject *self) {
 			A2DynamicDelegate *dynamicDelegate = [self dynamicDelegateForProtocol: protocol];
 			return dynamicDelegate.realDelegate;
-		});
+		} copy] autorelease]);
 	}
 	else
 	{


### PR DESCRIPTION
In some circumstances imp_implementationWithBlock deadlocks without doing this.

I found a reference to this workaround online, it's pretty cargo-culty but it solved the problem for me.

Interestingly, the potential for deadlocking is mentioned in [a testcase in the runtime](http://www.opensource.apple.com/source/objc4/objc4-493.9/test/blocksAsImps.m) so it seems that the bug has been fixed.
