### PR TITLE
Fix off by one error in extracting key path string.

### DIFF
--- a/BlocksKit/NSObject+BlockObservation.m
+++ b/BlocksKit/NSObject+BlockObservation.m
@@ -162,7 +162,7 @@ static dispatch_queue_t BKObserverMutationQueue() {
 			[self associateValue:nil withKey:&kObserverBlocksKey];
 		
 		[withIdentifier each:^(NSString *key, BKObserver *trampoline) {
-			NSString *keyPath = [key substringToIndex:key.length - token.length - 2];
+			NSString *keyPath = [key substringToIndex:key.length - token.length - 1];
 			
 			if (!trampoline || ![trampoline.keyPaths containsObject:keyPath])
 				return;


### PR DESCRIPTION
I found that removeObserversWithIdentifier: in NSObject+BlockObservation.m doesn't work, because the keyPath string is one character too short.
