### PR TITLE
Fix crash during `removeAllBlockObservers` 

### DIFF
--- a/BlocksKit/NSObject+BlockObservation.m
+++ b/BlocksKit/NSObject+BlockObservation.m
@@ -7,6 +7,7 @@
 #import "NSObject+AssociatedObjects.h"
 #import "NSDictionary+BlocksKit.h"
 #import "NSArray+BlocksKit.h"
+#import "NSSet+BlocksKit.h"
 
 @interface BKObserver : NSObject {
 	id _task;
@@ -173,15 +174,16 @@ static dispatch_queue_t BKObserverMutationQueue() {
 }
 
 - (void)removeAllBlockObservers {
-	dispatch_sync(BKObserverMutationQueue(), ^{
-		NSMutableDictionary *observationDictionary = [self associatedValueForKey:&kObserverBlocksKey];
-		[observationDictionary each:^(NSString *key, BKObserver *trampoline) {
-			[trampoline.keyPaths each:^(NSString *keyPath) {
-				[self removeObserver:trampoline forKeyPath:keyPath];
-			}];
-		}];
-		[self associateValue:nil withKey:&kObserverBlocksKey];
-	});
+    dispatch_sync(BKObserverMutationQueue(), ^{
+        NSMutableDictionary *observationDictionary = [self associatedValueForKey:&kObserverBlocksKey];
+        NSSet *trampolinesToRemove = [NSSet setWithArray:[observationDictionary allValues]];
+        [trampolinesToRemove each:^(BKObserver *trampoline) {
+            [trampoline.keyPaths each:^(NSString *keyPath) {
+                [self removeObserver:trampoline forKeyPath:keyPath];
+            }];
+        }];
+        [self associateValue:nil withKey:&kObserverBlocksKey];
+    });
 }
 
 @end


### PR DESCRIPTION
This pull request fixes a crash that occurs when one invokes `removeAllBlockObservers` for an object that has had multiple key path observers registered via the `addObserverForKeyPaths:` family of methods.

The issue is that when the removal retrieves the observation dictionary from the associated object, the same trampoline object appears multiple times within the values of the observation dictionary. The code then iterates over each trampoline object attempting to tear down each observed key path. The first iteration succeeds and then the second iteration crashes as the key path is no longer being observed. The patch collects all the trampoline objects into a set to unique them before iteration.
