### PR TITLE
Make -select: not concurrent as other -select:'s

### DIFF
--- a/BlocksKit/NSDictionary+BlocksKit.m
+++ b/BlocksKit/NSDictionary+BlocksKit.m
@@ -38,7 +38,7 @@
 - (NSDictionary *)select:(BKKeyValueValidationBlock)block {
 	NSParameterAssert(block != nil);
 	
-	NSArray *keys = [[self keysOfEntriesWithOptions:NSEnumerationConcurrent passingTest:^(id key, id obj, BOOL *stop) {
+	NSArray *keys = [[self keysOfEntriesPassingTest:^(id key, id obj, BOOL *stop) {
 		return block(key, obj);
 	}] allObjects];
 	


### PR DESCRIPTION
Only -[NSDictionary select:] is concurrent, others like -[NSArray select:] not.
