### PR TITLE
Fix default connection:willCacheResponse: behavior

### DIFF
--- a/BlocksKit/NSURLConnection+BlocksKit.m
+++ b/BlocksKit/NSURLConnection+BlocksKit.m
@@ -266,7 +266,7 @@ static char kResponseLengthKey;
 	if (realDelegate && [realDelegate respondsToSelector:@selector(connection:willCacheResponse:)])
 		return [realDelegate connection: connection willCacheResponse: cachedResponse];
 	
-	return nil;
+	return cachedResponse;
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {


### PR DESCRIPTION
If the delegate provided to NSURLConnection+BlocksKit doesn't implement connection:willCacheResponse:, BlocksKit will return nil from this method. This changes the default behavior of NSURLConnection. 

Better to return cachedResponse unmodified. 
