### PR TITLE
Adding arguments name to make easier auto-completion

### DIFF
--- a/BlocksKit/NSURLConnection+BlocksKit.h
+++ b/BlocksKit/NSURLConnection+BlocksKit.h
@@ -113,7 +113,7 @@
  @param success A code block that acts on instances of NSURLResponse and NSData in the event of a successful connection.
  @param failure A code block that acts on instances of NSURLResponse and NSError in the event of a failed connection.
  */
-+ (NSURLConnection *)startConnectionWithRequest:(NSURLRequest *)request successHandler:(void(^)(NSURLConnection *, NSURLResponse *, NSData *))success failureHandler:(void(^)(NSURLConnection *, NSError *))failure;
++ (NSURLConnection *)startConnectionWithRequest:(NSURLRequest *)request successHandler:(void(^)(NSURLConnection *urlConnection, NSURLResponse *urlResponse, NSData *data))success failureHandler:(void(^)(NSURLConnection *urlConnection, NSError *error))failure;
 
 /** Returns an initialized block-backed URL connection.
  
@@ -128,12 +128,12 @@
  @param request The URL request to load.
  @param block A code block that acts on instances of NSURLResponse and NSData in the event of a successful connection.
  */
-- (id)initWithRequest:(NSURLRequest *)request completionHandler:(void(^)(NSURLConnection *, NSURLResponse *, NSData *))block;
+- (id)initWithRequest:(NSURLRequest *)request completionHandler:(void(^)(NSURLConnection *urlConnection, NSURLResponse *urlResponse, NSData *data))block;
 
 /** Causes the connection to begin loading data, if it has not already, with the specified block to be fired on successful completion.
  
  @param block A code block that acts on instances of NSURLResponse and NSData in the event of a successful connection.
  */
-- (void)startWithCompletionBlock:(void(^)(NSURLConnection *, NSURLResponse *, NSData *))block;
+- (void)startWithCompletionBlock:(void(^)(NSURLConnection *urlConnection, NSURLResponse *urlResponse, NSData *data))block;
 
 @end

--- a/BlocksKit/UIKit/UIAlertView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIAlertView+BlocksKit.h
@@ -46,7 +46,7 @@
  @param otherButtonTitles Titles of additional buttons to add to the receiver.
  @param block A block of code to be fired on the dismissal of the alert view.
  */
-+ (void) showAlertViewWithTitle: (NSString *) title message: (NSString *) message cancelButtonTitle: (NSString *) cancelButtonTitle otherButtonTitles: (NSArray *) otherButtonTitles handler: (void (^)(UIAlertView *, NSInteger)) block;
++ (void) showAlertViewWithTitle: (NSString *) title message: (NSString *) message cancelButtonTitle: (NSString *) cancelButtonTitle otherButtonTitles: (NSArray *) otherButtonTitles handler: (void (^)(UIAlertView *alertView, NSInteger buttonIndex)) block;
 
 /** Creates and returns a new alert view with only a title and cancel button.
 


### PR DESCRIPTION
If you try to use:

``` Objective-c
[UIAlertView showAlertViewWithTitle:(NSString *) message:(NSString *) cancelButtonTitle:(NSString *) otherButtonTitles:(NSArray *) handler:^(UIAlertView *, NSInteger) {
            // code
}]
```

You will have to auto-complete alertView and buttonIndex variable name... it's kind of a pain in the b*tt to do it each time...

Now

``` Objective-c
[UIAlertView showAlertViewWithTitle:(NSString *) message:(NSString *) cancelButtonTitle:(NSString *) otherButtonTitles:(NSArray *) handler:^(UIAlertView *alertView, NSInteger buttonIndex) {
            // code
}]
```

Same on NSURLConnection.

It's the only place where it wasn't done (or I think so...), in methods which take a block it's already define in BKGlobals.h...

``` Objective-c
typedef void (^BKGestureRecognizerBlock)(UIGestureRecognizer *sender, UIGestureRecognizerState state, CGPoint location);
```
