### PR TITLE
Remove 'all exceptions' breakpoint 

### DIFF
--- a/BlocksKit.xcodeproj/xcshareddata/xcdebugger/Breakpoints.xcbkptlist
+++ b/BlocksKit.xcodeproj/xcshareddata/xcdebugger/Breakpoints.xcbkptlist
@@ -2,13 +2,4 @@
 <Bucket
    type = "4"
    version = "1.0">
-   <ExceptionBreakpoints>
-      <ExceptionBreakpoint
-         shouldBeEnabled = "Yes"
-         ignoreCount = "0"
-         continueAfterRunningActions = "No"
-         scope = "0"
-         stopOnStyle = "0">
-      </ExceptionBreakpoint>
-   </ExceptionBreakpoints>
 </Bucket>


### PR DESCRIPTION
Leaving a breakpoint on all exceptions can disrupt another developer's workflow. If they disable the breakpoint and commit, their submodule is broken. Feel free to pull or not pull at your discretion. Thanks for your work!
