### PR TITLE
a2_methodSignaturesCompatible only checks first character now.

### DIFF
--- a/BlocksKit/A2DynamicDelegate.m
+++ b/BlocksKit/A2DynamicDelegate.m
@@ -15,12 +15,12 @@ Protocol *a2_delegateProtocol(Class cls);
 
 static BOOL a2_methodSignaturesCompatible(NSMethodSignature *methodSignature, NSMethodSignature *blockSignature)
 {
-	if (strcmp(methodSignature.methodReturnType, blockSignature.methodReturnType))
+	if (methodSignature.methodReturnType[0] != blockSignature.methodReturnType[0])
 		return NO;
 
 	NSUInteger numberOfArguments = methodSignature.numberOfArguments;
 	for (NSUInteger i = 2; i < numberOfArguments; i++) {
-		if (strcmp([methodSignature getArgumentTypeAtIndex: i], [blockSignature getArgumentTypeAtIndex: i - 1]))
+		if ([methodSignature getArgumentTypeAtIndex: i][0] != [blockSignature getArgumentTypeAtIndex: i - 1][0])
 			return NO;
 	}
 	return YES;


### PR DESCRIPTION
I changed `a2_methodSignaturesCompatible` to only compare the first character of each argument type because there are new modern objc compilers out there which encode the whole expected objc class into a block argument. This means that the argument signature of the first argument of

```
^{UITextField *textField} {

};
```

will be `@"UITextField"` instead of a plain `@` which causes `a2_methodSignaturesCompatible` to fail.
