### PR TITLE
Block call should be called after MFMessageComposeViewController is dismissed if possible (ios >= 5)

### DIFF
--- a/BlocksKit/MessageUI/MFMessageComposeViewController+BlocksKit.m
+++ b/BlocksKit/MessageUI/MFMessageComposeViewController+BlocksKit.m
@@ -19,16 +19,25 @@
 		[realDelegate messageComposeViewController:controller didFinishWithResult:result];
 	
 	void(^block)(MFMessageComposeViewController *, MessageComposeResult) = [self blockImplementationForMethod:_cmd];
-	if (block)
-		block(controller, result);
 	
-	if (!shouldDismiss) {
-	        #if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
-	            [controller dismissModalViewControllerAnimated:YES];
-                #else
-                    [controller dismissViewControllerAnimated:YES completion:nil];
-                #endif
-         }
+    if (!shouldDismiss)
+    {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
+        [controller dismissModalViewControllerAnimated:YES];
+        if (block)
+            block(controller, result);
+#else
+        __weak id wcontroller = controller;
+        [controller dismissViewControllerAnimated:YES completion:^{
+            if (block)
+                block(wcontroller, result);
+        }];
+#endif
+    }
+    else if (block)
+    {
+        block(controller, result);
+    }
 }
 
 @end


### PR DESCRIPTION
Block call is being called right before dismissing the modal but there are some scenarios where you need to know when the dismiss animation is done.
