### PR TITLE
(for next) changed BKTimerBlock to receive NSTimer instance.

### DIFF
--- a/BlocksKit/Core/NSTimer+BlocksKit.m
+++ b/BlocksKit/Core/NSTimer+BlocksKit.m
@@ -13,22 +13,21 @@
 
 @implementation NSTimer (BlocksKit)
 
-+ (id)bk_scheduledTimerWithTimeInterval:(NSTimeInterval)inTimeInterval block:(void (^)(NSTimeInterval time))block repeats:(BOOL)inRepeats
++ (id)bk_scheduledTimerWithTimeInterval:(NSTimeInterval)inTimeInterval block:(void (^)(NSTimer *timer))block repeats:(BOOL)inRepeats
 {
 	NSParameterAssert(block != nil);
 	return [self scheduledTimerWithTimeInterval:inTimeInterval target:self selector:@selector(bk_executeBlockFromTimer:) userInfo:[block copy] repeats:inRepeats];
 }
 
-+ (id)bk_timerWithTimeInterval:(NSTimeInterval)inTimeInterval block:(void (^)(NSTimeInterval time))block repeats:(BOOL)inRepeats
++ (id)bk_timerWithTimeInterval:(NSTimeInterval)inTimeInterval block:(void (^)(NSTimer *timer))block repeats:(BOOL)inRepeats
 {
 	NSParameterAssert(block != nil);
 	return [self timerWithTimeInterval:inTimeInterval target:self selector:@selector(bk_executeBlockFromTimer:) userInfo:[block copy] repeats:inRepeats];
 }
 
 + (void)bk_executeBlockFromTimer:(NSTimer *)aTimer {
-	NSTimeInterval time = [aTimer timeInterval];
-	void (^block)(NSTimeInterval) = [aTimer userInfo];
-	if (block) block(time);
+	void (^block)(NSTimer *) = [aTimer userInfo];
+	if (block) block(aTimer);
 }
 
 @end

--- a/Tests/NSTimerBlocksKitTest.m
+++ b/Tests/NSTimerBlocksKitTest.m
@@ -4,7 +4,6 @@
 //
 
 #import "NSTimerBlocksKitTest.h"
-#import <BlocksKit/BlocksKit.h>
 
 @implementation NSTimerBlocksKitTest {
 	NSInteger _total;	
@@ -15,7 +14,7 @@
 }
 
 - (void)testScheduledTimer {
-	void(^timerBlock)(NSTimeInterval) = ^(NSTimeInterval time) {
+	void(^timerBlock)(NSTimer *) = ^(NSTimer *timer) {
 		_total++;
 		NSLog(@"total is %lu", (unsigned long)_total);
 	};
@@ -27,7 +26,7 @@
 }
 
 - (void)testRepeatedlyScheduledTimer {
-	void(^timerBlock)(NSTimeInterval) = ^(NSTimeInterval time) {
+	void(^timerBlock)(NSTimer) = ^(NSTimer *timer) {
 		_total++;
 		NSLog(@"total is %lu", (unsigned long)_total);
 	};
@@ -40,7 +39,7 @@
 }
 
 - (void)testUnscheduledTimer {
-	void(^timerBlock)(NSTimeInterval) = ^(NSTimeInterval time) {
+	void(^timerBlock)(NSTimer *) = ^(NSTimer *timer) {
 		_total++;
 		NSLog(@"total is %lu", (unsigned long)_total);
 	};
@@ -53,7 +52,7 @@
 }
 
 - (void)testRepeatableUnscheduledTimer {
-	void(^timerBlock)(NSTimeInterval) = ^(NSTimeInterval time) {
+	void(^timerBlock)(NSTimeInterval) = ^(NSTimer *timer) {
 		_total += 1;
 		NSLog(@"total is %lu", (unsigned long)_total);
 	};


### PR DESCRIPTION
That way you can invalidate the timer within the block.

You can still get the interval using [timer timerInterval].
(this version is for next)
