### PR TITLE
Added commented xcconfigs for App bundle vs. sub_umbrella Framework Target build

### DIFF
--- a/BlocksKit.xcodeproj/project.pbxproj
+++ b/BlocksKit.xcodeproj/project.pbxproj
@@ -401,6 +401,8 @@
 		6CF22D3C161F32C4002FD317 /* MFMailComposeViewControllerBlocksKitTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFMailComposeViewControllerBlocksKitTest.m; sourceTree = "<group>"; };
 		6CF22D3D161F32C4002FD317 /* MFMessageComposeViewControllerBlocksKitTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MFMessageComposeViewControllerBlocksKitTest.h; sourceTree = "<group>"; };
 		6CF22D3E161F32C5002FD317 /* MFMessageComposeViewControllerBlocksKitTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MFMessageComposeViewControllerBlocksKitTest.m; sourceTree = "<group>"; };
+		7B548FEC17D5B6B000496435 /* BundledFramework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = BundledFramework.xcconfig; path = BlocksKit/BundledFramework.xcconfig; sourceTree = "<group>"; };
+		7B548FED17D5EEC000496435 /* SubUmbrellaFramework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = SubUmbrellaFramework.xcconfig; path = BlocksKit/SubUmbrellaFramework.xcconfig; sourceTree = "<group>"; };
 		7BE3719217D4364000F20298 /* BlocksKit Mac Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BlocksKit Mac Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BE3719317D4364000F20298 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		7BE3719617D4364000F20298 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -559,6 +561,8 @@
 				6CC08FD11385555D00DDEABB /* iOS */,
 				7BE3719317D4364000F20298 /* Cocoa.framework */,
 				7BE3719517D4364000F20298 /* Other Frameworks */,
+				7B548FEC17D5B6B000496435 /* BundledFramework.xcconfig */,
+				7B548FED17D5EEC000496435 /* SubUmbrellaFramework.xcconfig */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1491,13 +1495,13 @@
 		};
 		6CC40A821447BB1400E47595 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7B548FEC17D5B6B000496435 /* BundledFramework.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_CURRENT_VERSION = 1.8.2;
 				FRAMEWORK_VERSION = A;
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = "BlocksKit/BlocksKit-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
@@ -1506,13 +1510,13 @@
 		};
 		6CC40A831447BB1400E47595 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7B548FEC17D5B6B000496435 /* BundledFramework.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_CURRENT_VERSION = 1.8.2;
 				FRAMEWORK_VERSION = A;
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = "BlocksKit/BlocksKit-Info.plist";
-				INSTALL_PATH = "@executable_path/../Frameworks";
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = framework;
 			};
@@ -1611,7 +1615,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Tests/Mac Demo/BlocksKit Mac Demo-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@rpath";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -1628,7 +1632,7 @@
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Tests/Mac Demo/BlocksKit Mac Demo-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@rpath";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/BlocksKit/BundledFramework.xcconfig
+++ b/BlocksKit/BundledFramework.xcconfig
@@ -1,0 +1,41 @@
+
+//  BundledFramework.xcconfig - BlocksKit - Created by Alex Gray on 9/3/13.
+
+
+// You have TWO options for linking / including BlocksKit/any Mac framework..
+
+
+// Option A: 	Inside your YourApp.app. 	(A private framework) This is how the included "Mac Demo App" does it.
+// Option B: 	Inside YourKit.framework. (Yours is the "umbrella" framework, Blockskit becomes the "sub_umbrella")
+
+// Step 1:	 	For either option, you need to drag (or "Add Files..") the Bk.xcodeproj to YOUR blue .xcodeproj file in Navigator.
+//					Then, add a build phase to your App or parent framework's target (not the BK framework) like..
+
+//	+ Copy Files ->  + Add / select the "BlocksKit.framework" target under products -> Destination "Frameworks"
+
+
+//	Step 2: 		You HAVE to set YOUR app OR your framework to "search" for frameworks internally at runtime via the special variable "@rpath"..
+
+// LD_RUNPATH_SEARCH_PATHS = @rpath  // It wont work setting it here.. do it in YOUR App or Umbrella Framework target,
+
+
+// Step 3:  Choose Option A or B by		->	Clicking on BlocksKit.xcodeproj in Navigator
+//													-> Click the Blue Project icon above the other targets
+//													-> Expand configurations and select the right config file based on where you'll include BK.
+
+
+//	-------------------------------------------------- The below instructions are unique to this configuration.
+
+
+//	THIS xcconfig file is for OPTION A! the App bundle traget. This loads BK relative to your app's executable.
+
+// Framework Will end up in 	"YourApp.app/Contents/Frameworks/BlocksKit.framework"
+// Bundle executable is at 	"YourApp.app/Contents/MacOS/YourApp"
+
+INSTALL_PATH 	=	@executable_path/../Frameworks
+
+// By linking your app to BlocksKit like so... 							OTHER_LDFLAGS		= -framework BlocksKit
+// and importing the Blockskit Header in your project...   			#import <BlocksKit/BlocksKit.h>
+// BlocksKit will be avilable to your app / classes.
+
+

--- a/BlocksKit/SubUmbrellaFramework.xcconfig
+++ b/BlocksKit/SubUmbrellaFramework.xcconfig
@@ -1,0 +1,43 @@
+
+//  BundledFramework.xcconfig - BlocksKit - Created by Alex Gray on 9/3/13.
+
+
+// You have TWO options for linking / including BlocksKit/any Mac framework..
+
+
+// Option A: 	Inside your YourApp.app. 	(A private framework)
+// Option B: 	Inside YourKit.framework. (Yours is the "umbrella" framework, Blockskit becomes the "sub_umbrella")
+
+// Step 1:	 	For either option, you need to drag (or "Add Files..") the Bk.xcodeproj to YOUR blue .xcodeproj file in Navigator.
+//					Then, add a build phase to your App or parent framework's target (not the BK framework) like..
+
+//	+ Copy Files ->  + Add / select the "BlocksKit.framework" target under products -> Destination "Frameworks"
+
+
+//	Step 2: 		You HAVE to set YOUR app OR your framework to "search" for frameworks internally at runtime via the special variable "@rpath"..
+
+// LD_RUNPATH_SEARCH_PATHS = @rpath  // It wont work setting it here.. do it in YOUR App or Umbrella Framework target,
+
+
+// Step 3:  Choose Option A or B by		->	Clicking on BlocksKit.xcodeproj in Navigator
+//													-> Click the Blue Project icon above the other targets
+//													-> Expand configurations and select the right config file based on where you'll include BK.
+
+
+//	-------------------------------------------------- The below instructions are unique to this configuration.
+
+
+//	THIS xcconfig file is for OPTION B! the FRAMEWORK traget. This loads BK relative to an "umbrella framework".
+
+// Blocks Will end up in 				"SomeApp.app/Contents/Frameworks/YourKit.framework/Versions/A/Frameworks/BlocksKit.framework"
+// The framework LOADING BK is at 	"SomeApp.app/Contents/Frameworks/YourKit.framework/Versions/A/YourKit"
+
+// SO we set BlocksKit's installname, relative to the LOADER (aka your framework's) @rpath
+
+INSTALL_PATH	=	@loader_path/Frameworks
+
+// By linking your parent/umbrella framework to BlocksKit like so... 		OTHER_LDFLAGS	= -sub_umbrella BlocksKit
+// and importing the Blockskit Header in your project...   				 		#import <BlocksKit/BlocksKit.h>
+// BlocksKit will be avilable to your framework's classes and any app that links with your umbrella framework.
+
+

--- a/Tests/Mac Demo/BKApp.m
+++ b/Tests/Mac Demo/BKApp.m
@@ -23,7 +23,7 @@
 #pragma mark - NSTimer+BlocksKit
 
 	// timer w/ block will bump our displayCount property and repeat itself, triggering KVO notification below
-	_tmr = [NSTimer scheduledTimerWithTimeInterval:.4 block:^(NSTimeInterval time) { self.displayCt++; } repeats:YES];
+	_tmr = [NSTimer scheduledTimerWithTimeInterval:.4 block:^(NSTimer *t) { self.displayCt++; } repeats:YES];
 
 #pragma mark - NSObject+BlockObservation
 


### PR DESCRIPTION
From the .xconfig's comments....

>  You have TWO options for linking / including BlocksKit/any Mac framework..
> Option A:     Inside your YourApp.app.    (A private framework) This is how the included "Mac Demo App" does it.
> Option B:     Inside YourKit.framework. (Yours is the "umbrella" framework, Blockskit becomes the "sub_umbrella")

Also fixed method mismatch in updated NSTimer call in demo app. and
erroneous 10.9 deployment targets.

![130903-0003](https://f.cloud.github.com/assets/262517/1072078/06aa9cb4-1487-11e3-8a2a-b3ce4737f455.png)
