### PR TITLE
Fix warnings building with -Warc-bridge-casts-disallowed-in-nonarc

### DIFF
--- a/BlocksKit/BKMacros.h
+++ b/BlocksKit/BKMacros.h
@@ -52,10 +52,10 @@ static inline id BKNextHelper(NSArray *array, CFMutableDictionaryRef *eachTableP
         *eachTablePtr = CFDictionaryCreateMutable(NULL, 0, &keycb, &kCFTypeDictionaryValueCallBacks);
     }
 
-    NSEnumerator *enumerator = (__bridge id)CFDictionaryGetValue(*eachTablePtr, (__bridge CFArrayRef)array);
+    NSEnumerator *enumerator = (id)CFDictionaryGetValue(*eachTablePtr, (CFArrayRef)array);
     if (!enumerator) {
         enumerator = [array objectEnumerator];
-        CFDictionarySetValue(*eachTablePtr, (__bridge CFArrayRef)array, (__bridge void *)enumerator);
+        CFDictionarySetValue(*eachTablePtr, (CFArrayRef)array, (void *)enumerator);
     }
     return [enumerator nextObject];
 }


### PR DESCRIPTION
In Xcode 4.6.3, building with iOS 6.1 as a target and using `-Warc-bridge-casts-disallowed-in-nonarc`, I get several warnings in `BKMacros.h`: `'__bridge' casts have no effect when not using ARC`.

This pull request just removes those `__bridge` casts so the project builds properly.

I haven't tested this on OSX so not sure if there are any other side effects, but it would be nice to build on iOS with stricter settings. Thanks for a great project!
