### PR TITLE
fixed logic so view controllers are dismissed correctly.

### DIFF
--- a/BlocksKit/MessageUI/MFMailComposeViewController+BlocksKit.m
+++ b/BlocksKit/MessageUI/MFMailComposeViewController+BlocksKit.m
@@ -23,7 +23,7 @@
 		[realDelegate mailComposeController:controller didFinishWithResult:result error:error];
 
 	void (^block)(MFMailComposeViewController *, MFMailComposeResult, NSError *) = [self blockImplementationForMethod:_cmd];
-	if (!shouldDismiss) {
+	if (shouldDismiss) {
 		if (block) block(controller, result, error);
 	} else {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000

--- a/BlocksKit/MessageUI/MFMessageComposeViewController+BlocksKit.m
+++ b/BlocksKit/MessageUI/MFMessageComposeViewController+BlocksKit.m
@@ -23,7 +23,7 @@
 		[realDelegate messageComposeViewController:controller didFinishWithResult:result];
 
 	void (^block)(MFMessageComposeViewController *, MessageComposeResult) = [self blockImplementationForMethod:_cmd];
-	if (!shouldDismiss) {
+	if (shouldDismiss) {
 		if (block) block(controller, result);
 	} else {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000


### PR DESCRIPTION
I think the correct logic was included here

https://github.com/segiddins/BlocksKit/commit/b29701fd2fd49a641b6f814bcc91eb1990547deb

and made incorrect here

https://github.com/pandamonia/BlocksKit/commit/e1c17f0cf86187c6551c5911d5780022abad25a2#diff-d8fe9ab7726ee7be872fe43af088b28b

The naming of the variable makes it hard to understand but I believe this is the intended functionality and how it worked in version 1
