### PR TITLE
Unchecked malloc return value

### DIFF
--- a/BlocksKit/DynamicDelegate/A2BlockInvocation.m
+++ b/BlocksKit/DynamicDelegate/A2BlockInvocation.m
@@ -484,11 +484,11 @@ static ffi_type *a2_typeForSignature(const char *argumentType, void *(^allocate)
 
 	if (_returnLength) {
 		void *returnValue = malloc(_returnLength);
-        if (returnValue) {
-            [self getReturnValue:returnValue];
-            [inv setReturnValue:returnValue];
-            free(returnValue);
-        }
+		if (returnValue) {
+			[self getReturnValue:returnValue];
+			[inv setReturnValue:returnValue];
+			free(returnValue);
+		}
 	}
 }
 


### PR DESCRIPTION
This malloc isn't being checked for a NULL result, and while unlikely, it still fails our security/standards static analysis. 
