### PR TITLE
Remove duplicate references

### DIFF
--- a/BlocksKit.podspec
+++ b/BlocksKit.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'DynamicDelegate' do |ss|
-    ss.source_files = 'BlocksKit/BlocksKit.h', 'BlocksKit/DynamicDelegate/*.{h,m}', 'BlocksKit/DynamicDelegate/Foundation/*.{h,m}'
+    ss.source_files = 'BlocksKit/DynamicDelegate/*.{h,m}', 'BlocksKit/DynamicDelegate/Foundation/*.{h,m}'
     ss.ios.dependency 'BlocksKit/MiniFFI'
     ss.osx.library = 'ffi'
   end


### PR DESCRIPTION
The BlocksKit.h file was added twice to the Xcode Copy Headers build phase.

This change should fix the Xcode warning caused by it: he Copy Headers build phase contains duplicate references for one or more files"
