### PR TITLE
Removed a redundant documentation entry

### DIFF
--- a/BlocksKit/Core/NSObject+BKBlockObservation.h
+++ b/BlocksKit/Core/NSObject+BKBlockObservation.h
@@ -78,7 +78,6 @@
  @param options The NSKeyValueObservingOptions to use.
  @param task A block with no return argument and three parameters: the
  reciever, the key path of the value change, and the change dictionary.
- @param task A block responding to the reciever, the key path, and the KVO change.
  @return A unique identifier for removing
  observation with removeObserverWithBlockToken:.
  @see addObserverForKeyPath:identifier:options:task:


### PR DESCRIPTION
per CLANG_WARN_DOCUMENTATION_COMMENTS (Xcode 5.1.1)
