### PR TITLE
Skip Install for iOS static library.

### DIFF
--- a/BlocksKit.xcodeproj/project.pbxproj
+++ b/BlocksKit.xcodeproj/project.pbxproj
@@ -1363,6 +1363,7 @@
 				);
 				PRODUCT_NAME = BlocksKit;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Debug;
@@ -1400,6 +1401,7 @@
 				);
 				PRODUCT_NAME = BlocksKit;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
 				VALIDATE_PRODUCT = YES;
 			};


### PR DESCRIPTION
Otherwise, if you add BlocksKit as a dependency
target to another project, Xcode
“Product->Archive” creates a
“Generic Xcode Archive” instead of an .ipa file.
