### PR TITLE
Fixes header include issues when not using as a Pod

### DIFF
--- a/BlocksKit/BlocksKit.h
+++ b/BlocksKit/BlocksKit.h
@@ -25,19 +25,19 @@
 //  THE SOFTWARE.
 //
 
-#import <BlocksKit/NSArray+BlocksKit.h>
-#import <BlocksKit/NSDictionary+BlocksKit.h>
-#import <BlocksKit/NSIndexSet+BlocksKit.h>
-#import <BlocksKit/NSInvocation+BlocksKit.h>
-#import <BlocksKit/NSMutableArray+BlocksKit.h>
-#import <BlocksKit/NSMutableDictionary+BlocksKit.h>
-#import <BlocksKit/NSMutableIndexSet+BlocksKit.h>
-#import <BlocksKit/NSMutableOrderedSet+BlocksKit.h>
-#import <BlocksKit/NSMutableSet+BlocksKit.h>
-#import <BlocksKit/NSObject+BKAssociatedObjects.h>
-#import <BlocksKit/NSObject+BKBlockExecution.h>
-#import <BlocksKit/NSObject+BKBlockObservation.h>
-#import <BlocksKit/NSOrderedSet+BlocksKit.h>
-#import <BlocksKit/NSSet+BlocksKit.h>
-#import <BlocksKit/NSTimer+BlocksKit.h>
-#import <BlocksKit/BKMacros.h>
+#import <BlocksKit/Core/NSArray+BlocksKit.h>
+#import <BlocksKit/Core/NSDictionary+BlocksKit.h>
+#import <BlocksKit/Core/NSIndexSet+BlocksKit.h>
+#import <BlocksKit/Core/NSInvocation+BlocksKit.h>
+#import <BlocksKit/Core/NSMutableArray+BlocksKit.h>
+#import <BlocksKit/Core/NSMutableDictionary+BlocksKit.h>
+#import <BlocksKit/Core/NSMutableIndexSet+BlocksKit.h>
+#import <BlocksKit/Core/NSMutableOrderedSet+BlocksKit.h>
+#import <BlocksKit/Core/NSMutableSet+BlocksKit.h>
+#import <BlocksKit/Core/NSObject+BKAssociatedObjects.h>
+#import <BlocksKit/Core/NSObject+BKBlockExecution.h>
+#import <BlocksKit/Core/NSObject+BKBlockObservation.h>
+#import <BlocksKit/Core/NSOrderedSet+BlocksKit.h>
+#import <BlocksKit/Core/NSSet+BlocksKit.h>
+#import <BlocksKit/Core/NSTimer+BlocksKit.h>
+#import <BlocksKit/Core/BKMacros.h>

--- a/BlocksKit/DynamicDelegate/A2DynamicDelegate.h
+++ b/BlocksKit/DynamicDelegate/A2DynamicDelegate.h
@@ -4,8 +4,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <BlocksKit/NSObject+A2BlockDelegate.h>
-#import <BlocksKit/NSObject+A2DynamicDelegate.h>
+#import <DynamicDelegate/NSObject+A2BlockDelegate.h>
+#import <DynamicDelegate/NSObject+A2DynamicDelegate.h>
 
 /** A2DynamicDelegate implements a class's delegate, data source, or other
  delegated protocol by associating protocol methods with a block implementation.

--- a/BlocksKit/DynamicDelegate/NSObject+A2DynamicDelegate.h
+++ b/BlocksKit/DynamicDelegate/NSObject+A2DynamicDelegate.h
@@ -3,7 +3,7 @@
 //  BlocksKit
 //
 
-#import <BlocksKit/A2DynamicDelegate.h>
+#import <DynamicDelegate/A2DynamicDelegate.h>
 #import <Foundation/Foundation.h>
 
 /** The A2DynamicDelegate category to NSObject provides the primary interface


### PR DESCRIPTION
It seems that the folders where re-arranged at some point but not all the header imports were updates. Pods glosses over these issues somehow.
