### PR TITLE
Changed UIActionSheet default handler delegate method linking

### DIFF
--- a/BlocksKit/UIKit/UIActionSheet+BlocksKit.m
+++ b/BlocksKit/UIKit/UIActionSheet+BlocksKit.m
@@ -21,8 +21,7 @@
 	if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:clickedButtonAtIndex:)])
 		[realDelegate actionSheet:actionSheet clickedButtonAtIndex:buttonIndex];
 	
-	void (^block)(void) = self.handlers[@(buttonIndex)];
-	if (block) block();
+
 }
 
 - (void)willPresentActionSheet:(UIActionSheet *)actionSheet
@@ -63,6 +62,9 @@
 
 	void (^block)(UIActionSheet *, NSInteger) = [self blockImplementationForMethod:_cmd];
 	if (block) block(actionSheet, buttonIndex);
+	
+	void (^handlerblock)(void) = self.handlers[@(buttonIndex)];
+	if (handlerblock) handlerblock();
 }
 
 - (void)actionSheetCancel:(UIActionSheet *)actionSheet


### PR DESCRIPTION
In many cases (especially on the iPad), if a new controller is
presented in response to an action of UIActionSheet by using the
clickedButtonAtIndex delegate method, the presentation fail because the
action sheet is still shown (a warning in the console confirm this). By
calling the default handlers on DidDismiss this problem is solved.
