### PR TITLE
Adopt nullability annotations for XCode 6.3 and Swift 1.2

### DIFF
--- a/BlocksKit.xcodeproj/project.pbxproj
+++ b/BlocksKit.xcodeproj/project.pbxproj
@@ -1119,7 +1119,7 @@
 		DB4B7D3619FD867F00C459A6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "Zachary Waldowski and Pandamonia LLC";
 				TargetAttributes = {
 					DB4B7D3E19FD867F00C459A6 = {
@@ -1492,6 +1492,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB4B7DA019FD8F9B00C459A6 /* Project-Debug.xcconfig */;
 			buildSettings = {
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -1499,6 +1502,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB4B7DA119FD8F9B00C459A6 /* Project-Release.xcconfig */;
 			buildSettings = {
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 			};
 			name = Release;
 		};

--- a/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit Mac Demo.xcscheme
+++ b/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit Mac Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -72,7 +72,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DB4B7F8519FDA00D00C459A6"
@@ -90,7 +91,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DB4B7F8519FDA00D00C459A6"

--- a/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit Mac.xcscheme
+++ b/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit iOS Legacy.xcscheme
+++ b/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit iOS Legacy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit iOS.xcscheme
+++ b/BlocksKit.xcodeproj/xcshareddata/xcschemes/BlocksKit iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BlocksKit/Core/NSArray+BlocksKit.h
+++ b/BlocksKit/Core/NSArray+BlocksKit.h
@@ -6,6 +6,13 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CGBase.h> // for CGFloat
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSArray.
 
  Both inspired by and resembling Smalltalk syntax, these utilities
@@ -218,3 +225,7 @@
 - (BOOL)bk_corresponds:(NSArray *)list withBlock:(BOOL (^)(id obj1, id obj2))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSDictionary+BlocksKit.h
+++ b/BlocksKit/Core/NSDictionary+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extension for NSDictionary.
 
  Both inspired by and resembling Smalltalk syntax, this utility
@@ -108,3 +115,7 @@
 - (BOOL)bk_all:(BOOL (^)(id key, id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSIndexSet+BlocksKit.h
+++ b/BlocksKit/Core/NSIndexSet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSIndexSet.
 
  Both inspired by and resembling Smalltalk syntax, these utilities
@@ -117,3 +124,7 @@
 - (BOOL)bk_none:(BOOL (^)(NSUInteger index))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSInvocation+BlocksKit.h
+++ b/BlocksKit/Core/NSInvocation+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** BlocksKit extensions for NSInvocation. */
 @interface NSInvocation (BlocksKit)
 
@@ -31,3 +38,7 @@
 + (NSInvocation *)bk_invocationWithTarget:(id)target block:(void (^)(id target))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSMapTable+BlocksKit.h
+++ b/BlocksKit/Core/NSMapTable+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 @interface NSMapTable (BlocksKit)
 
 /** Loops through the maptable and executes the given block using each item.
@@ -104,3 +111,7 @@
 - (void)bk_performMap:(id (^)(id key, id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSMutableArray+BlocksKit.h
+++ b/BlocksKit/Core/NSMutableArray+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSMutableArray.
 
  These utilities expound upon the BlocksKit additions to the immutable
@@ -48,3 +55,7 @@
 - (void)bk_performMap:(id (^)(id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSMutableDictionary+BlocksKit.h
+++ b/BlocksKit/Core/NSMutableDictionary+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSMutableDictionary.
 
  These utilities expound upon the BlocksKit additions to the immutable
@@ -44,3 +51,7 @@
 - (void)bk_performMap:(id (^)(id key, id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSMutableIndexSet+BlocksKit.h
+++ b/BlocksKit/Core/NSMutableIndexSet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSMutableIndexSet.
 
  These utilities expound upon the BlocksKit additions to the immutable
@@ -38,5 +45,8 @@
  */
 - (void)bk_performMap:(NSUInteger (^)(NSUInteger index))block;
 
-
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSMutableOrderedSet+BlocksKit.h
+++ b/BlocksKit/Core/NSMutableOrderedSet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSMutableOrderedSet.
 
  These utilities expound upon the BlocksKit additions to the immutable
@@ -48,3 +55,7 @@
 - (void)bk_performMap:(id (^)(id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSMutableSet+BlocksKit.h
+++ b/BlocksKit/Core/NSMutableSet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSMutableSet.
 
  These utilities expound upon the BlocksKit additions to the immutable
@@ -48,3 +55,7 @@
 - (void)bk_performMap:(id (^)(id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSObject+BKAssociatedObjects.h
+++ b/BlocksKit/Core/NSObject+BKAssociatedObjects.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Objective-C wrapper for 10.6+ associated object API.
 
  In Mac OS X Snow Leopard and iOS 3.0, Apple introduced an addition to the
@@ -156,3 +163,7 @@
 + (void)bk_removeAllAssociatedObjects;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSObject+BKBlockExecution.h
+++ b/BlocksKit/Core/NSObject+BKBlockExecution.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block execution on *any* object.
 
  This category overhauls the `performSelector:` utilities on
@@ -118,3 +125,7 @@
 + (void)bk_cancelBlock:(id <NSObject, NSCopying>)block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSObject+BKBlockObservation.h
+++ b/BlocksKit/Core/NSObject+BKBlockObservation.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Blocks wrapper for key-value observation.
 
  In Mac OS X Panther, Apple introduced an API called "key-value
@@ -135,3 +142,7 @@
 - (void)bk_removeAllBlockObservers;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSOrderedSet+BlocksKit.h
+++ b/BlocksKit/Core/NSOrderedSet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSOrderedSet.
 
  Both inspired by and resembling Smalltalk syntax, these utilities allow for
@@ -165,4 +172,9 @@
  corresponding element in another ordered set.
  */
 - (BOOL)bk_corresponds:(NSOrderedSet *)list withBlock:(BOOL (^)(id obj1, id obj2))block;
+
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSSet+BlocksKit.h
+++ b/BlocksKit/Core/NSSet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block extensions for NSSet.
 
  Both inspired by and resembling Smalltalk syntax, these utilities allows for
@@ -131,3 +138,7 @@
 - (BOOL)bk_all:(BOOL (^)(id obj))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/Core/NSTimer+BlocksKit.h
+++ b/BlocksKit/Core/NSTimer+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Simple category on NSTimer to give it blocks capability.
 
  Created by [Jiva DeVoe](https://github.com/jivadevoe) as `NSTimer-Blocks`.
@@ -39,3 +46,7 @@
 + (instancetype)bk_timerWithTimeInterval:(NSTimeInterval)seconds block:(void (^)(NSTimer *timer))block repeats:(BOOL)repeats;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/DynamicDelegate/Foundation/NSCache+BlocksKit.h
+++ b/BlocksKit/DynamicDelegate/Foundation/NSCache+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** NSCache with block adding of objects
 
  This category allows you to conditionally add objects to
@@ -51,3 +58,7 @@
 @property (nonatomic, copy, setter = bk_setWillEvictBlock:) void (^bk_willEvictBlock)(NSCache *cache, id obj);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/DynamicDelegate/Foundation/NSURLConnection+BlocksKit.h
+++ b/BlocksKit/DynamicDelegate/Foundation/NSURLConnection+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** NSURLConnection with both delegate and block callback support.
 
  It also adds useful block handlers for tracking upload and download progress.
@@ -56,19 +63,19 @@
  in an instance of NSURLConnection.  It only works on block-backed
  NSURLConnection instances.
  */
-@property (nonatomic, weak, setter = setDelegate:) id delegate;
+@property (nonatomic, weak, setter = setDelegate:, nullable) id delegate;
 
 /** The block fired once the connection recieves a response from the server.
 
  This block corresponds to the connection:didReceiveResponse: method
  of NSURLConnectionDataDelegate. */
-@property (nonatomic, copy, setter = bk_setResponseBlock:) void (^bk_responseBlock)(NSURLConnection *connection, NSURLResponse *response);
+@property (nonatomic, copy, setter = bk_setResponseBlock:, nullable) void (^bk_responseBlock)(NSURLConnection *connection, NSURLResponse *response);
 
 /** The block fired upon the failure of the connection.
 
  This block corresponds to the connection:didFailWithError:
  method of NSURLConnectionDelegate. */
-@property (nonatomic, copy, setter = bk_setFailureBlock:) void (^bk_failureBlock)(NSURLConnection *connection, NSError *error);
+@property (nonatomic, copy, setter = bk_setFailureBlock:, nullable) void (^bk_failureBlock)(NSURLConnection *connection, NSError *error);
 
 /** The block that  upon the successful completion of the connection.
 
@@ -80,7 +87,7 @@
  the recieved data to an instance NSMutableData is left up to the user due
  to the behavior of frameworks that use NSURLConnection.
  */
-@property (nonatomic, copy, setter = bk_setSuccessBlock:) void (^bk_successBlock)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData);
+@property (nonatomic, copy, setter = bk_setSuccessBlock:, nullable) void (^bk_successBlock)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData);
 
 /** The block fired every time new data is sent to the server,
  representing the current percentage of completion.
@@ -89,7 +96,7 @@
  connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:
  method of NSURLConnectionDelegate.
  */
-@property (nonatomic, copy, setter = bk_setUploadBlock:) void (^bk_uploadBlock)(double percent);
+@property (nonatomic, copy, setter = bk_setUploadBlock:, nullable) void (^bk_uploadBlock)(double percent);
 
 /** The block fired every time new data is recieved from the server,
  representing the current percentage of completion.
@@ -97,7 +104,7 @@
  This block corresponds to the connection:didRecieveData:
  method of NSURLConnectionDelegate.
  */
-@property (nonatomic, copy, setter = bk_setDownloadBlock:) void (^bk_downloadBlock)(double percent);
+@property (nonatomic, copy, setter = bk_setDownloadBlock:, nullable) void (^bk_downloadBlock)(double percent);
 
 /** Creates and returns an initialized block-backed URL connection that does not begin to load the data for the URL request.
 
@@ -113,7 +120,7 @@
  @param success A code block that acts on instances of NSURLResponse and NSData in the event of a successful connection.
  @param failure A code block that acts on instances of NSURLResponse and NSError in the event of a failed connection.
  */
-+ (NSURLConnection *)bk_startConnectionWithRequest:(NSURLRequest *)request successHandler:(void (^)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData))success failureHandler:(void (^)(NSURLConnection *connection, NSError *error))failure;
++ (NSURLConnection *)bk_startConnectionWithRequest:(NSURLRequest *)request successHandler:(nullable void (^)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData))success failureHandler:(nullable void (^)(NSURLConnection *connection, NSError *error))failure;
 
 /** Returns an initialized block-backed URL connection.
 
@@ -128,12 +135,16 @@
  @param request The URL request to load.
  @param block A code block that acts on instances of NSURLResponse and NSData in the event of a successful connection.
  */
-- (instancetype)bk_initWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData))block NS_REPLACES_RECEIVER;
+- (instancetype)bk_initWithRequest:(NSURLRequest *)request completionHandler:(nullable void (^)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData))block NS_REPLACES_RECEIVER;
 
 /** Causes the connection to begin loading data, if it has not already, with the specified block to be fired on successful completion.
 
  @param block A code block that acts on instances of NSURLResponse and NSData in the event of a successful connection.
  */
-- (void)bk_startWithCompletionBlock:(void (^)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData))block;
+- (void)bk_startWithCompletionBlock:(nullable void (^)(NSURLConnection *connection, NSURLResponse *response, NSData *responseData))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIActionSheet+BlocksKit.h
+++ b/BlocksKit/UIKit/UIActionSheet+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** UIActionSheet without delegates!
 
  This set of extensions and convenience classes allows
@@ -41,14 +48,14 @@
  @param title The header of the action sheet.
  @return A newly created action sheet.
  */
-+ (instancetype)bk_actionSheetWithTitle:(NSString *)title;
++ (instancetype)bk_actionSheetWithTitle:(nullable NSString *)title;
 
 /** Returns a configured action sheet with only a title and cancel button.
 
  @param title The header of the action sheet.
  @return An instantiated actionSheet.
  */
-- (instancetype)bk_initWithTitle:(NSString *)title NS_REPLACES_RECEIVER;
+- (instancetype)bk_initWithTitle:(nullable NSString *)title NS_REPLACES_RECEIVER;
 
 ///-----------------------------------
 /// @name Adding buttons
@@ -59,7 +66,7 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block;
+- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(nullable void (^)(void))block;
 
 /** Set the destructive (red) button with an associated code block.
  
@@ -83,7 +90,7 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block;
+- (NSInteger)bk_setCancelButtonWithTitle:(nullable NSString *)title handler:(nullable void (^)(void))block;
 
 ///-----------------------------------
 /// @name Altering actions
@@ -94,14 +101,14 @@
  @param block A code block, or nil to set no response.
  @param index The index of a button already added to the action sheet.
 */
-- (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index;
+- (void)bk_setHandler:(nullable void (^)(void))block forButtonAtIndex:(NSInteger)index;
 
 /** The block that is to be fired when a button is pressed.
  
  @param index The index of a button already added to the action sheet.
  @return A code block, or nil if no block is assigned.
  */
-- (void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index;
+- (nullable void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index;
 
 /** The block to be fired when the action sheet is dismissed with the cancel
  button and/or action.
@@ -114,15 +121,19 @@
 @property (nonatomic, copy, setter = bk_setCancelBlock:) void (^bk_cancelBlock)(void);
 
 /** The block to be fired before the action sheet will show. */
-@property (nonatomic, copy, setter = bk_setWillShowBlock:) void (^bk_willShowBlock)(UIActionSheet *actionSheet);
+@property (nonatomic, copy, setter = bk_setWillShowBlock:, nullable) void (^bk_willShowBlock)(UIActionSheet *actionSheet);
 
 /** The block to be fired when the action sheet shows. */
-@property (nonatomic, copy, setter = bk_setDidShowBlock:) void (^bk_didShowBlock)(UIActionSheet *actionSheet);
+@property (nonatomic, copy, setter = bk_setDidShowBlock:, nullable) void (^bk_didShowBlock)(UIActionSheet *actionSheet);
 
 /** The block to be fired before the action sheet will dismiss. */
-@property (nonatomic, copy, setter = bk_setWillDismissBlock:) void (^bk_willDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex);
+@property (nonatomic, copy, setter = bk_setWillDismissBlock:, nullable) void (^bk_willDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex);
 
 /** The block to be fired after the action sheet dismisses. */
-@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex);
+@property (nonatomic, copy, setter = bk_setDidDismissBlock:, nullable) void (^bk_didDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIAlertView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIAlertView+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** UIAlertView without delegates!
 
  This set of extensions and convenience classes allows
@@ -48,14 +55,14 @@
  
  @return The UIAlertView.
  */
-+ (instancetype)bk_showAlertViewWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSArray *)otherButtonTitles handler:(void (^)(UIAlertView *alertView, NSInteger buttonIndex))block;
++ (instancetype)bk_showAlertViewWithTitle:(nullable NSString *)title message:(nullable NSString *)message cancelButtonTitle:(nullable NSString *)cancelButtonTitle otherButtonTitles:(nullable NSArray *)otherButtonTitles handler:(nullable void (^)(UIAlertView *alertView, NSInteger buttonIndex))block;
 
 /** Creates and returns a new alert view with only a title and cancel button.
 
  @param title The title of the alert view.
  @return A newly created alert view.
  */
-+ (instancetype)bk_alertViewWithTitle:(NSString *)title;
++ (instancetype)bk_alertViewWithTitle:(nullable NSString *)title;
 
 /** Creates and returns a new alert view with only a title, message, and cancel button.
 
@@ -63,7 +70,7 @@
  @param message The message content of the alert.
  @return A newly created alert view.
  */
-+ (instancetype)bk_alertViewWithTitle:(NSString *)title message:(NSString *)message;
++ (instancetype)bk_alertViewWithTitle:(nullable NSString *)title message:(nullable NSString *)message;
 
 /** Returns a configured alert view with only a title, message, and cancel button.
  
@@ -71,7 +78,7 @@
  @param message The message content of the alert.
  @return An instantiated alert view.
  */
-- (instancetype)bk_initWithTitle:(NSString *)title message:(NSString *)message NS_REPLACES_RECEIVER;
+- (instancetype)bk_initWithTitle:(nullable NSString *)title message:(nullable NSString *)message NS_REPLACES_RECEIVER;
 
 ///-----------------------------------
 /// @name Adding buttons
@@ -82,14 +89,14 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block;
+- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(nullable void (^)(void))block;
 
 /** Set the title and trigger of the cancel button.
  
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block;
+- (NSInteger)bk_setCancelButtonWithTitle:(nullable NSString *)title handler:(nullable void (^)(void))block;
 
 ///-----------------------------------
 /// @name Altering actions
@@ -100,7 +107,7 @@
  @param block A code block, or nil to set no response.
  @param index The index of a button already added to the action sheet.
  */
-- (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index;
+- (void)bk_setHandler:(nullable void (^)(void))block forButtonAtIndex:(NSInteger)index;
 
 /** The block that is to be fired when a button is pressed.
  
@@ -116,21 +123,25 @@
  property multiple times but multiple cancel buttons will
  not be generated.
  */
-@property (nonatomic, copy, setter = bk_setCancelBlock:) void (^bk_cancelBlock)(void);
+@property (nonatomic, copy, setter = bk_setCancelBlock:, nullable) void (^bk_cancelBlock)(void);
 
 /** The block to be fired before the alert view will show. */
-@property (nonatomic, copy, setter = bk_setWillShowBlock:) void (^bk_willShowBlock)(UIAlertView *alertView);
+@property (nonatomic, copy, setter = bk_setWillShowBlock:, nullable) void (^bk_willShowBlock)(UIAlertView *alertView);
 
 /** The block to be fired when the alert view shows. */
-@property (nonatomic, copy, setter = bk_setDidShowBlock:) void (^bk_didShowBlock)(UIAlertView *alertView);
+@property (nonatomic, copy, setter = bk_setDidShowBlock:, nullable) void (^bk_didShowBlock)(UIAlertView *alertView);
 
 /** The block to be fired before the alert view will dismiss. */
-@property (nonatomic, copy, setter = bk_setWillDismissBlock:) void (^bk_willDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex);
+@property (nonatomic, copy, setter = bk_setWillDismissBlock:, nullable) void (^bk_willDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex);
 
 /** The block to be fired after the alert view dismisses. */
-@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex);
+@property (nonatomic, copy, setter = bk_setDidDismissBlock:, nullable) void (^bk_didDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex);
 
 /** The block to be fired to determine whether the first non-cancel should be enabled */
-@property (nonatomic, copy, setter = bk_SetShouldEnableFirstOtherButtonBlock:) BOOL (^bk_shouldEnableFirstOtherButtonBlock)(UIAlertView *alertView) NS_AVAILABLE_IOS(5_0);
+@property (nonatomic, copy, setter = bk_SetShouldEnableFirstOtherButtonBlock:, nullable) BOOL (^bk_shouldEnableFirstOtherButtonBlock)(UIAlertView *alertView) NS_AVAILABLE_IOS(5_0);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIBarButtonItem+BlocksKit.h
+++ b/BlocksKit/UIKit/UIBarButtonItem+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block event initialization for UIBarButtonItem.
 
  This set of extensions has near-drop-in replacements
@@ -37,7 +44,7 @@
  @param style The style of the item. One of the constants defined in UIBarButtonItemStyle.
  @param action The block that gets fired on the button press.
  */
-- (instancetype)bk_initWithImage:(UIImage *)image style:(UIBarButtonItemStyle)style handler:(void (^)(id sender))action NS_REPLACES_RECEIVER;
+- (instancetype)bk_initWithImage:(nullable UIImage *)image style:(UIBarButtonItemStyle)style handler:(void (^)(id sender))action NS_REPLACES_RECEIVER;
 
 /** Creates and returns a configured item using the specified image and style.
 
@@ -47,7 +54,7 @@
  @param style The style of the item. One of the constants defined in UIBarButtonItemStyle.
  @param action The block that gets fired on the button press.
  */
-- (instancetype)bk_initWithImage:(UIImage *)image landscapeImagePhone:(UIImage *)landscapeImagePhone style:(UIBarButtonItemStyle)style handler:(void (^)(id sender))action NS_REPLACES_RECEIVER;
+- (instancetype)bk_initWithImage:(nullable UIImage *)image landscapeImagePhone:(nullable UIImage *)landscapeImagePhone style:(UIBarButtonItemStyle)style handler:(void (^)(id sender))action NS_REPLACES_RECEIVER;
 
 /** Creates and returns a configured item using the specified text and style.
  
@@ -56,6 +63,10 @@
  @param style The style of the item. One of the constants defined in UIBarButtonItemStyle.
  @param action The block that gets fired on the button press.
  */
-- (instancetype)bk_initWithTitle:(NSString *)title style:(UIBarButtonItemStyle)style handler:(void (^)(id sender))action NS_REPLACES_RECEIVER;
+- (instancetype)bk_initWithTitle:(nullable NSString *)title style:(UIBarButtonItemStyle)style handler:(void (^)(id sender))action NS_REPLACES_RECEIVER;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIControl+BlocksKit.h
+++ b/BlocksKit/UIKit/UIControl+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block control event handling for UIControl.
 
  Includes code by the following:
@@ -47,3 +54,7 @@
 - (BOOL)bk_hasEventHandlersForControlEvents:(UIControlEvents)controlEvents;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIGestureRecognizer+BlocksKit.h
+++ b/BlocksKit/UIKit/UIGestureRecognizer+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block functionality for UIGestureRecognizer.
 
  Use of the delay property is pretty straightforward, although
@@ -85,7 +92,7 @@
 /** Allows the block that will be fired by the gesture recognizer
  to be modified after the fact.
  */
-@property (nonatomic, copy, setter = bk_setHandler:) void (^bk_handler)(UIGestureRecognizer *sender, UIGestureRecognizerState state, CGPoint location);
+@property (nonatomic, copy, setter = bk_setHandler:, nullable) void (^bk_handler)(UIGestureRecognizer *sender, UIGestureRecognizerState state, CGPoint location);
 
 /** Allows the length of the delay after which the gesture
  recognizer will be fired to modify. */
@@ -102,3 +109,7 @@
 - (void)bk_cancel;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIImagePickerController+BlocksKit.h
+++ b/BlocksKit/UIKit/UIImagePickerController+BlocksKit.h
@@ -7,6 +7,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** UIImagePickerController with block callback.
 
  Created by [Yas Kuraishi](https://github.com/YasKuraishi) and contributed to
@@ -25,6 +32,10 @@
 /**
  *	The block that fires after the user cancels out of picker
  */
-@property (nonatomic, copy) void(^bk_didCancelBlock)(UIImagePickerController *);
+@property (nonatomic, copy, nullable) void(^bk_didCancelBlock)(UIImagePickerController *);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIPopoverController+BlocksKit.h
+++ b/BlocksKit/UIKit/UIPopoverController+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block functionality for UIPopoverController.
  
  Created by [Alexsander Akers](https://github.com/a2) and contributed to BlocksKit.
@@ -14,9 +21,13 @@
 @interface UIPopoverController (BlocksKit)
 
 /** The block to be called when the popover controller will dismiss the popover. Return NO to prevent the dismissal of the view. */
-@property (nonatomic, copy, setter = bk_setShouldDismissBlock:) BOOL (^bk_shouldDismissBlock)(UIPopoverController *popoverController);
+@property (nonatomic, copy, setter = bk_setShouldDismissBlock:, nullable) BOOL (^bk_shouldDismissBlock)(UIPopoverController *popoverController);
 
 /** The block to be called when the user has taken action to dismiss the popover. This is not called when -dismissPopoverAnimated: is called directly. */
-@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIPopoverController *popoverController);
+@property (nonatomic, copy, setter = bk_setDidDismissBlock:, nullable) void (^bk_didDismissBlock)(UIPopoverController *popoverController);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UITextField+BlocksKit.h
+++ b/BlocksKit/UIKit/UITextField+BlocksKit.h
@@ -7,6 +7,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block callbacks for UITextField.
 
  @warning UITextField is only available on a platform with UIKit.
@@ -21,44 +28,48 @@
  *
  *  The return value indicates whether the receiver should begin editing
  */
-@property (nonatomic, copy) BOOL(^bk_shouldBeginEditingBlock)(UITextField *);
+@property (nonatomic, copy, nullable) BOOL(^bk_shouldBeginEditingBlock)(UITextField *);
 
 /**
  *	The block that fires after the receiver begins editing
  */
-@property (nonatomic, copy) void(^bk_didBeginEditingBlock)(UITextField *);
+@property (nonatomic, copy, nullable) void(^bk_didBeginEditingBlock)(UITextField *);
 
 /**
  *	The block that fires before the receiver ends editing
  *
  *  The return value indicates whether the receiver should end editing
  */
-@property (nonatomic, copy) BOOL(^bk_shouldEndEditingBlock)(UITextField *);
+@property (nonatomic, copy, nullable) BOOL(^bk_shouldEndEditingBlock)(UITextField *);
 
 /**
  *	The block that fires after the receiver ends editing
  */
-@property (nonatomic, copy) void(^bk_didEndEditingBlock)(UITextField *);
+@property (nonatomic, copy, nullable) void(^bk_didEndEditingBlock)(UITextField *);
 
 /**
  *	The block that fires when the receiver's text will change
  *
  *  The return value indicates whether the receiver should replace the characters in the given range with the replacement string
  */
-@property (nonatomic, copy) BOOL(^bk_shouldChangeCharactersInRangeWithReplacementStringBlock)(UITextField *, NSRange, NSString *);
+@property (nonatomic, copy, nullable) BOOL(^bk_shouldChangeCharactersInRangeWithReplacementStringBlock)(UITextField *, NSRange, NSString *);
 
 /**
  *	The block that fires when the receiver's clear button is pressed
  *
  *  The return value indicates whether the receiver should clear its contents
  */
-@property (nonatomic, copy) BOOL(^bk_shouldClearBlock)(UITextField *);
+@property (nonatomic, copy, nullable) BOOL(^bk_shouldClearBlock)(UITextField *);
 
 /**
  *	The block that fires when the keyboard's return button is pressed and the receiver is the first responder
  *
  *  The return value indicates whether the receiver should return
  */
-@property (nonatomic, copy) BOOL(^bk_shouldReturnBlock)(UITextField *);
+@property (nonatomic, copy, nullable) BOOL(^bk_shouldReturnBlock)(UITextField *);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIView+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Convenience on-touch methods for UIView.
 
  Includes code by the following:
@@ -67,3 +74,7 @@
 - (void)bk_eachSubview:(void (^)(UIView *subview))block;
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif

--- a/BlocksKit/UIKit/UIWebView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIWebView+BlocksKit.h
@@ -5,6 +5,13 @@
 
 #import <UIKit/UIKit.h>
 
+#if __has_feature(nullability) // Xcode 6.3+
+#pragma clang assume_nonnull begin
+#else
+#define nullable
+#define __nullable
+#endif
+
 /** Block callbacks for UIWebView.
 
  @warning UIWebView is only available on a platform with UIKit.
@@ -17,15 +24,19 @@
  @warning If the delegate implements webView:shouldStartLoadWithRequest:navigationType:,
  the return values of both the delegate method and the block will be considered.
 */
-@property (nonatomic, copy, setter = bk_setShouldStartLoadBlock:) BOOL (^bk_shouldStartLoadBlock)(UIWebView *webView, NSURLRequest *request, UIWebViewNavigationType navigationType);
+@property (nonatomic, copy, setter = bk_setShouldStartLoadBlock:, nullable) BOOL (^bk_shouldStartLoadBlock)(UIWebView *webView, NSURLRequest *request, UIWebViewNavigationType navigationType);
 
 /** The block that is fired when the web view starts loading. */
-@property (nonatomic, copy, setter = bk_setDidStartLoadBlock:) void (^bk_didStartLoadBlock)(UIWebView *webView);
+@property (nonatomic, copy, setter = bk_setDidStartLoadBlock:, nullable) void (^bk_didStartLoadBlock)(UIWebView *webView);
 
 /** The block that is fired when the web view finishes loading. */
-@property (nonatomic, copy, setter = bk_setDidFinishLoadBlock:) void (^bk_didFinishLoadBlock)(UIWebView *webView);
+@property (nonatomic, copy, setter = bk_setDidFinishLoadBlock:, nullable) void (^bk_didFinishLoadBlock)(UIWebView *webView);
 
 /** The block that is fired when the web view stops loading due to an error. */
-@property (nonatomic, copy, setter = bk_setDidFinishWithErrorBlock:) void (^bk_didFinishWithErrorBlock)(UIWebView *webView, NSError *error);
+@property (nonatomic, copy, setter = bk_setDidFinishWithErrorBlock:, nullable) void (^bk_didFinishWithErrorBlock)(UIWebView *webView, NSError *error);
 
 @end
+
+#if __has_feature(nullability)
+#pragma clang assume_nonnull end
+#endif


### PR DESCRIPTION
It's a little bit early for this PR, but i'm making it anyway for the future =) Apple is introducing [nullability annotations](https://developer.apple.com/swift/blog/?id=25) in XCode 6.3 and Swift 1.2. 

These allow better interoperability with Swift, and provide nice compiler warnings for Objective-C, when API is used in non-supported way. 

I tried adding annotations where they made sense from API perspective, so this stuff should be reviewed. These changes should be backwards-compatible with XCode 6.2 and 6.1, since all defines are wrapped in if __has_feature(nullability).
