### PR TITLE
[UIBarButtomItem] Replace self pointer with sender for forwarding the event sender

### DIFF
--- a/BlocksKit/UIKit/UIBarButtonItem+BlocksKit.m
+++ b/BlocksKit/UIKit/UIBarButtonItem+BlocksKit.m
@@ -59,7 +59,7 @@ static const void *BKBarButtonItemBlockKey = &BKBarButtonItemBlockKey;
 - (void)bk_handleAction:(UIBarButtonItem *)sender
 {
 	void (^block)(id) = objc_getAssociatedObject(self, BKBarButtonItemBlockKey);
-	if (block) block(self);
+	if (block) block(sender);
 }
 
 @end


### PR DESCRIPTION
In common case, this UIBarButtonItem's self pointer and sender are the same object when triggering the event, the event will invoke -[UIApplication sendAction:to:from:forEvent:] by runloop, we shouldn't "override" the event sender object here.

Please review, thanks!