### PR TITLE
Fix action sheet may be presented more than once

### DIFF
--- a/BlocksKit/UIKit/UIActionSheet+BlocksKit.m
+++ b/BlocksKit/UIKit/UIActionSheet+BlocksKit.m
@@ -76,6 +76,7 @@
 
 	void (^block)(UIActionSheet *, NSInteger) = [self blockImplementationForMethod:_cmd];
 	if (block) block(actionSheet, buttonIndex);
+	self.didHandleButtonClick = NO;
 }
 
 - (void)actionSheetCancel:(UIActionSheet *)actionSheet


### PR DESCRIPTION
With the previous workaround for iPad iOS 8 bug, it was no longer possible to present the same action sheet more than once (the button clicks would no longer work). Now it works fine.