### PR TITLE
Add default implementation to imagePickerControllerDidCancel:

### DIFF
--- a/BlocksKit/UIKit/UIImagePickerController+BlocksKit.m
+++ b/BlocksKit/UIKit/UIImagePickerController+BlocksKit.m
@@ -31,6 +31,10 @@
 
 	void (^block)(UIImagePickerController *) = [self blockImplementationForMethod:_cmd];
 	if (block) block(picker);
+
+	if (!block && ![realDelegate respondsToSelector:@selector(imagePickerControllerDidCancel:)]) {
+		[picker dismissViewControllerAnimated:YES completion:nil];
+	}
 }
 
 @end


### PR DESCRIPTION
We encountered a problem (ImagePickerController cancel button not working) when integrate BlocksKit to our project, the reason is we didn't implement imagePickerControllerDidCancel delegate method.

But Dismiss ImagePickerController is the system default implementation for imagePickerControllerDidCancel, however using A2DynamicUIImagePickerControllerDelegate to check delegate is responds to imagePickerControllerDidCancel, the result is false, so system default implementation is lost. This commit fixes this.