### PR TITLE
Add long press gesture and fix imageView not respond issue

### DIFF
--- a/BlocksKit/UIKit/UIView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIView+BlocksKit.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
  - Kevin O'Neill. <https://github.com/kevinoneill>. 2011. BSD.
  - Jake Marsh. <https://github.com/jakemarsh>. 2011. 
  - Zach Waldowski. <https://github.com/zwaldowski>. 2011.
+ - Mango Fang. <https://github.com/100mango>. 2016
 
  @warning UIView is only available on a platform with UIKit.
  */
@@ -68,6 +69,15 @@ NS_ASSUME_NONNULL_BEGIN
  @param block A code block that interacts with a UIView sender.
  */
 - (void)bk_eachSubview:(void (^)(UIView *subview))block;
+
+/**
+ *  Adds a recognizer for long press
+ *
+ *  @param duration The minimum period finger must press on the view for the gesture to be recognized
+ *  @param block    The handler for the UITapGestureRecognizer
+ */
+- (void)bk_longPressEndedAfter:(CGFloat)duration
+                    completion:(void (^)(void))block;
 
 @end
 

--- a/BlocksKit/UIKit/UIView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIView+BlocksKit.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Adds a recognizer for long press
  *
  *  @param duration The minimum period finger must press on the view for the gesture to be recognized
- *  @param block    The handler for the UITapGestureRecognizer
+ *  @param block    The handler for the UILongPressGestureRecognizer
  */
 - (void)bk_longPressEndedAfter:(CGFloat)duration
                     completion:(void (^)(void))block;

--- a/BlocksKit/UIKit/UIView+BlocksKit.m
+++ b/BlocksKit/UIKit/UIView+BlocksKit.m
@@ -30,6 +30,7 @@
 		}
 	}];
 
+    self.userInteractionEnabled = YES;
 	[self addGestureRecognizer:gesture];
 }
 
@@ -50,6 +51,20 @@
 	[self.subviews enumerateObjectsUsingBlock:^(UIView *subview, NSUInteger idx, BOOL *stop) {
 		block(subview);
 	}];
+}
+
+- (void)bk_longPressEndedAfter:(CGFloat)duration
+                    completion:(void (^)(void))block
+{
+    if (!block) return;
+    
+    UILongPressGestureRecognizer *gesture = [UILongPressGestureRecognizer bk_recognizerWithHandler:^(UIGestureRecognizer *sender, UIGestureRecognizerState state, CGPoint location) {
+        if (state == UIGestureRecognizerStateRecognized) block();
+    }];
+    
+    gesture.minimumPressDuration = duration;
+    [self addGestureRecognizer:gesture];
+    self.userInteractionEnabled = YES;
 }
 
 @end


### PR DESCRIPTION
1.Add long press gesture block based implementation.
2.Fix UIImageView not respond to user interaction issue.

[documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImageView_Class/index.html#//apple_ref/occ/instp/UIImageView/userInteractionEnabled)

> This property is inherited from the UIView parent class. This class
> changes the default value of this property to false.
