### PR TITLE
Added eachWithIndex: and mapWithIndex: method to iterate arrays

### DIFF
--- a/BlocksKit/Core/NSArray+BlocksKit.h
+++ b/BlocksKit/Core/NSArray+BlocksKit.h
@@ -34,6 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)bk_each:(void (^)(ObjectType obj))block;
 
+/** Loops through an array and executes the given block with each object.
+
+ @param block A double-argument, void-returning code block with index.
+ */
+- (void)bk_eachWithIndex:(void (^)(ObjectType obj, NSUInteger index))block;
+
 /** Enumerates through an array concurrently and executes
  the given block once for each object.
 
@@ -88,10 +94,22 @@ NS_ASSUME_NONNULL_BEGIN
 	   return [obj stringByAppendingString:@".png"]);
 	 }];
 
- @param block A single-argument, object-returning code block.
+ @param block A double-argument, object-returning code block with index.
  @return Returns an array of the objects returned by the block.
  */
 - (NSArray *)bk_map:(id (^)(ObjectType obj))block;
+
+/** Call the block once for each object and create an array of the return values.
+
+  This is sometimes referred to as a transform, mutating one of each object:
+      NSArray *new = [stringArray bk_map:^id(id obj, NSUInteger index) {
+        return [obj stringByAppendingString:@".png"]);
+      }];
+
+  @param block A single-argument, object-returning code block.
+  @return Returns an array of the objects returned by the block.
+ */
+- (NSArray *)bk_mapWithIndex:(id (^)(ObjectType obj, NSUInteger index))block;
 
 /** Behaves like map, but doesn't add NSNull objects if you return nil in the block.
 

--- a/BlocksKit/Core/NSArray+BlocksKit.m
+++ b/BlocksKit/Core/NSArray+BlocksKit.m
@@ -16,6 +16,15 @@
 	}];
 }
 
+- (void)bk_eachWithIndex:(void (^)(id obj, NSUInteger index))block
+{
+    NSParameterAssert(block != nil);
+
+    [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        block(obj, idx);
+    }];
+}
+
 - (void)bk_apply:(void (^)(id obj))block
 {
 	NSParameterAssert(block != nil);
@@ -67,6 +76,20 @@
 	}];
 
 	return result;
+}
+
+- (NSArray *)bk_mapWithIndex:(id (^)(id obj, NSUInteger index))block
+{
+    NSParameterAssert(block != nil);
+
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:self.count];
+
+    [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        id value = block(obj, idx) ?: [NSNull null];
+        [result addObject:value];
+    }];
+    
+    return result;
 }
 
 - (NSArray *)bk_compact:(id (^)(id obj))block


### PR DESCRIPTION
Sometimes iterate array need index which is similar with ruby syntax like this:

``` objectivec
    NSMutableArray *prompts = [@[@"time", @"score", @"fan"] mutableCopy];
    [promptLabels bk_each:^(UILabel *promptLabel, NSUInteger index) {
        promptLabel.text = prompts[index];
    }];
```

Thx for ur great lib
