### PR TITLE
Fix gesture recognizer current state in delayed block

### DIFF
--- a/BlocksKit/UIKit/UIGestureRecognizer+BlocksKit.m
+++ b/BlocksKit/UIKit/UIGestureRecognizer+BlocksKit.m
@@ -54,9 +54,10 @@ static const void *BKGestureRecognizerShouldHandleActionKey = &BKGestureRecogniz
 	
 	NSTimeInterval delay = self.bk_handlerDelay;
 	CGPoint location = [self locationInView:self.view];
+	UIGestureRecognizerState state = self.state;
 	void (^block)(void) = ^{
 		if (!self.bk_shouldHandleAction) return;
-		handler(self, self.state, location);
+		handler(self, state, location);
 	};
 
 	self.bk_shouldHandleAction = YES;


### PR DESCRIPTION
This commit will fix issue: #343 bk_whenTapped not get called

The current 'state' is now stored when the recognizer fires - that fixes issue when a delayed  handler block gets executed (I think this always happen since commit bc05cc8: Let bk_performBlock handle gesture fast path)

Great lib, thanks!
g4bor
