### PR TITLE
Support for App Extensions

### DIFF
--- a/BlocksKit/BKDefines.h
+++ b/BlocksKit/BKDefines.h
@@ -64,3 +64,9 @@
 #if !defined(BK_URL_CONNECTION_DEPRECATED)
 # define BK_URL_CONNECTION_DEPRECATED NS_DEPRECATED(10_5, 10_11, 2_0, 9_0, "The BlocksKit extensions for NSURLConnection are deprecated. Use NSURLSession instead.");
 #endif
+
+#if !defined(BK_DISABLE_FOR_APP_EXTENSION)
+# define BK_DISABLE_FOR_APP_EXTENSION NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extensions.")
+#endif
+
+

--- a/BlocksKit/UIKit/UIActionSheet+BlocksKit.h
+++ b/BlocksKit/UIKit/UIActionSheet+BlocksKit.h
@@ -42,14 +42,14 @@
  @param title The header of the action sheet.
  @return A newly created action sheet.
  */
-+ (instancetype)bk_actionSheetWithTitle:(NSString *)title BK_ALERT_CONTROLLER_DEPRECATED(2_0);
++ (instancetype)bk_actionSheetWithTitle:(NSString *)title BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Returns a configured action sheet with only a title and cancel button.
 
  @param title The header of the action sheet.
  @return An instantiated actionSheet.
  */
-- (instancetype)bk_initWithTitle:(NSString *)title BK_INITIALIZER BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (instancetype)bk_initWithTitle:(NSString *)title BK_INITIALIZER BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 ///-----------------------------------
 /// @name Adding buttons
@@ -60,7 +60,7 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Set the destructive (red) button with an associated code block.
  
@@ -71,7 +71,7 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_setDestructiveButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (NSInteger)bk_setDestructiveButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Set the title and trigger of the cancel button.
  
@@ -84,7 +84,7 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 ///-----------------------------------
 /// @name Altering actions
@@ -95,14 +95,14 @@
  @param block A code block, or nil to set no response.
  @param index The index of a button already added to the action sheet.
 */
-- (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block that is to be fired when a button is pressed.
  
  @param index The index of a button already added to the action sheet.
  @return A code block, or nil if no block is assigned.
  */
-- (void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired when the action sheet is dismissed with the cancel
  button and/or action.
@@ -112,18 +112,18 @@
  you can set this property multiple times and multiple cancel buttons will
  not be generated.
  */
-@property (nonatomic, copy, setter = bk_setCancelBlock:) void (^bk_cancelBlock)(void) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setCancelBlock:) void (^bk_cancelBlock)(void) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired before the action sheet will show. */
-@property (nonatomic, copy, setter = bk_setWillShowBlock:) void (^bk_willShowBlock)(UIActionSheet *actionSheet) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setWillShowBlock:) void (^bk_willShowBlock)(UIActionSheet *actionSheet) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired when the action sheet shows. */
-@property (nonatomic, copy, setter = bk_setDidShowBlock:) void (^bk_didShowBlock)(UIActionSheet *actionSheet) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setDidShowBlock:) void (^bk_didShowBlock)(UIActionSheet *actionSheet) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired before the action sheet will dismiss. */
-@property (nonatomic, copy, setter = bk_setWillDismissBlock:) void (^bk_willDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setWillDismissBlock:) void (^bk_willDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired after the action sheet dismisses. */
-@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIActionSheet *actionSheet, NSInteger buttonIndex) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 @end

--- a/BlocksKit/UIKit/UIActionSheet+BlocksKit.m
+++ b/BlocksKit/UIKit/UIActionSheet+BlocksKit.m
@@ -23,72 +23,72 @@
 
 - (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
 {
-	id realDelegate = self.realDelegate;
-	if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:clickedButtonAtIndex:)])
-		[realDelegate actionSheet:actionSheet clickedButtonAtIndex:buttonIndex];
-
-	void (^handler)(void) = self.handlers[@(buttonIndex)];
-
-	// Note: On iPad with iOS 8 GM seed, `actionSheet:clickedButtonAtIndex:` always gets called twice if you tap any button other than Cancel;
-	// In other words, assume you have two buttons: OK and Cancel; if you tap OK, this method will be called once for the OK button and once
-	// for the Cancel button. This could result in some really obscure bugs, so adding `didHandleButtonClick` property maintains iOS 7 compatibility.
-	if (handler && self.didHandleButtonClick == NO) {
-		self.didHandleButtonClick = YES;
-
-		// Presenting view controllers from within action sheet delegate does not work on iPad running iOS 8 GM seed, without delay
-		dispatch_async(dispatch_get_main_queue(), handler);
-	}
+    id realDelegate = self.realDelegate;
+    if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:clickedButtonAtIndex:)])
+        [realDelegate actionSheet:actionSheet clickedButtonAtIndex:buttonIndex];
+    
+    void (^handler)(void) = self.handlers[@(buttonIndex)];
+    
+    // Note: On iPad with iOS 8 GM seed, `actionSheet:clickedButtonAtIndex:` always gets called twice if you tap any button other than Cancel;
+    // In other words, assume you have two buttons: OK and Cancel; if you tap OK, this method will be called once for the OK button and once
+    // for the Cancel button. This could result in some really obscure bugs, so adding `didHandleButtonClick` property maintains iOS 7 compatibility.
+    if (handler && self.didHandleButtonClick == NO) {
+        self.didHandleButtonClick = YES;
+        
+        // Presenting view controllers from within action sheet delegate does not work on iPad running iOS 8 GM seed, without delay
+        dispatch_async(dispatch_get_main_queue(), handler);
+    }
 }
 
 - (void)willPresentActionSheet:(UIActionSheet *)actionSheet
 {
-	id realDelegate = self.realDelegate;
-	if (realDelegate && [realDelegate respondsToSelector:@selector(willPresentActionSheet:)])
-		[realDelegate willPresentActionSheet:actionSheet];
-
-	void (^block)(UIActionSheet *) = [self blockImplementationForMethod:_cmd];
-	if (block) block(actionSheet);
+    id realDelegate = self.realDelegate;
+    if (realDelegate && [realDelegate respondsToSelector:@selector(willPresentActionSheet:)])
+        [realDelegate willPresentActionSheet:actionSheet];
+    
+    void (^block)(UIActionSheet *) = [self blockImplementationForMethod:_cmd];
+    if (block) block(actionSheet);
 }
 
 - (void)didPresentActionSheet:(UIActionSheet *)actionSheet
 {
-	id realDelegate = self.realDelegate;
-	if (realDelegate && [realDelegate respondsToSelector:@selector(didPresentActionSheet:)])
-		[realDelegate didPresentActionSheet:actionSheet];
-
-	void (^block)(UIActionSheet *) = [self blockImplementationForMethod:_cmd];
-	if (block) block(actionSheet);
+    id realDelegate = self.realDelegate;
+    if (realDelegate && [realDelegate respondsToSelector:@selector(didPresentActionSheet:)])
+        [realDelegate didPresentActionSheet:actionSheet];
+    
+    void (^block)(UIActionSheet *) = [self blockImplementationForMethod:_cmd];
+    if (block) block(actionSheet);
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet willDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-	id realDelegate = self.realDelegate;
-	if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:willDismissWithButtonIndex:)])
-		[realDelegate actionSheet:actionSheet willDismissWithButtonIndex:buttonIndex];
-
-	void (^block)(UIActionSheet *, NSInteger) = [self blockImplementationForMethod:_cmd];
-	if (block) block(actionSheet, buttonIndex);
+    id realDelegate = self.realDelegate;
+    if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:willDismissWithButtonIndex:)])
+        [realDelegate actionSheet:actionSheet willDismissWithButtonIndex:buttonIndex];
+    
+    void (^block)(UIActionSheet *, NSInteger) = [self blockImplementationForMethod:_cmd];
+    if (block) block(actionSheet, buttonIndex);
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-	id realDelegate = self.realDelegate;
-	if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:didDismissWithButtonIndex:)])
-		[realDelegate actionSheet:actionSheet didDismissWithButtonIndex:buttonIndex];
-
-	void (^block)(UIActionSheet *, NSInteger) = [self blockImplementationForMethod:_cmd];
-	if (block) block(actionSheet, buttonIndex);
-	self.didHandleButtonClick = NO;
+    id realDelegate = self.realDelegate;
+    if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheet:didDismissWithButtonIndex:)])
+        [realDelegate actionSheet:actionSheet didDismissWithButtonIndex:buttonIndex];
+    
+    void (^block)(UIActionSheet *, NSInteger) = [self blockImplementationForMethod:_cmd];
+    if (block) block(actionSheet, buttonIndex);
+    self.didHandleButtonClick = NO;
 }
 
-- (void)actionSheetCancel:(UIActionSheet *)actionSheet
+- (void)actionSheetCancel:(UIActionSheet *)actionSheet BK_DISABLE_FOR_APP_EXTENSION
 {
-	id realDelegate = self.realDelegate;
-	if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheetCancel:)])
-		[realDelegate actionSheetCancel:actionSheet];
-
-	void (^block)(void) = actionSheet.bk_cancelBlock;
-	if (block) block();
+    id realDelegate = self.realDelegate;
+    if (realDelegate && [realDelegate respondsToSelector:@selector(actionSheetCancel:)])
+        [realDelegate actionSheetCancel:actionSheet];
+    
+    void (^block)(void) = actionSheet.bk_cancelBlock;
+    if (block) block();
 }
 
 @end
@@ -101,84 +101,84 @@
 
 + (void)load
 {
-	@autoreleasepool {
-		[self bk_registerDynamicDelegate];
-		[self bk_linkDelegateMethods:@{
-			@"bk_willShowBlock": @"willPresentActionSheet:",
-			@"bk_didShowBlock": @"didPresentActionSheet:",
-			@"bk_willDismissBlock": @"actionSheet:willDismissWithButtonIndex:",
-			@"bk_didDismissBlock": @"actionSheet:didDismissWithButtonIndex:"
-		}];
-	}
+    @autoreleasepool {
+        [self bk_registerDynamicDelegate];
+        [self bk_linkDelegateMethods:@{
+                                       @"bk_willShowBlock": @"willPresentActionSheet:",
+                                       @"bk_didShowBlock": @"didPresentActionSheet:",
+                                       @"bk_willDismissBlock": @"actionSheet:willDismissWithButtonIndex:",
+                                       @"bk_didDismissBlock": @"actionSheet:didDismissWithButtonIndex:"
+                                       }];
+    }
 }
 
 #pragma mark Initializers
 
 + (instancetype)bk_actionSheetWithTitle:(NSString *)title {
-	return [[[self class] alloc] bk_initWithTitle:title];
+    return [[[self class] alloc] bk_initWithTitle:title];
 }
 
 - (instancetype)bk_initWithTitle:(NSString *)title {
-	self = [self initWithTitle:title delegate:self.bk_dynamicDelegate cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil];
-	if (!self) { return nil; }
-	self.delegate = self.bk_dynamicDelegate;
-	return self;
+    self = [self initWithTitle:title delegate:self.bk_dynamicDelegate cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil];
+    if (!self) { return nil; }
+    self.delegate = self.bk_dynamicDelegate;
+    return self;
 }
 
 #pragma mark Actions
 
 - (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block {
-	NSAssert(title.length, @"A button without a title cannot be added to an action sheet.");
-	NSInteger index = [self addButtonWithTitle:title];
-	[self bk_setHandler:block forButtonAtIndex:index];
-	return index;
+    NSAssert(title.length, @"A button without a title cannot be added to an action sheet.");
+    NSInteger index = [self addButtonWithTitle:title];
+    [self bk_setHandler:block forButtonAtIndex:index];
+    return index;
 }
 
 - (NSInteger)bk_setDestructiveButtonWithTitle:(NSString *)title handler:(void (^)(void))block {
-	NSInteger index = [self bk_addButtonWithTitle:title handler:block];
-	self.destructiveButtonIndex = index;
-	return index;
+    NSInteger index = [self bk_addButtonWithTitle:title handler:block];
+    self.destructiveButtonIndex = index;
+    return index;
 }
 
 - (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block {
-	NSInteger cancelButtonIndex = self.cancelButtonIndex;
-
-	if ((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) && !title.length)
-		title = NSLocalizedString(@"Cancel", nil);
-
-	if (title.length)
-		cancelButtonIndex = [self addButtonWithTitle:title];
-
-	[self bk_setHandler:block forButtonAtIndex:cancelButtonIndex];
-	self.cancelButtonIndex = cancelButtonIndex;
-	return cancelButtonIndex;
+    NSInteger cancelButtonIndex = self.cancelButtonIndex;
+    
+    if ((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) && !title.length)
+        title = NSLocalizedString(@"Cancel", nil);
+    
+    if (title.length)
+        cancelButtonIndex = [self addButtonWithTitle:title];
+    
+    [self bk_setHandler:block forButtonAtIndex:cancelButtonIndex];
+    self.cancelButtonIndex = cancelButtonIndex;
+    return cancelButtonIndex;
 }
 
 #pragma mark Properties
 
 - (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index {
-	A2DynamicUIActionSheetDelegate *delegate = self.bk_ensuredDynamicDelegate;
-
-	if (block) {
-		delegate.handlers[@(index)] = [block copy];
-	} else {
-		[delegate.handlers removeObjectForKey:@(index)];
-	}
+    A2DynamicUIActionSheetDelegate *delegate = self.bk_ensuredDynamicDelegate;
+    
+    if (block) {
+        delegate.handlers[@(index)] = [block copy];
+    } else {
+        [delegate.handlers removeObjectForKey:@(index)];
+    }
 }
 
 - (void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index
 {
-	return [self.bk_dynamicDelegate handlers][@(index)];
+    return [self.bk_dynamicDelegate handlers][@(index)];
 }
 
 - (void (^)(void))bk_cancelBlock
 {
-	return [self bk_handlerForButtonAtIndex:self.cancelButtonIndex];
+    return [self bk_handlerForButtonAtIndex:self.cancelButtonIndex];
 }
 
 - (void)bk_setCancelBlock:(void (^)(void))block
 {
-	[self bk_setHandler:block forButtonAtIndex:self.cancelButtonIndex];
+    [self bk_setHandler:block forButtonAtIndex:self.cancelButtonIndex];
 }
 
 @end

--- a/BlocksKit/UIKit/UIAlertView+BlocksKit.h
+++ b/BlocksKit/UIKit/UIAlertView+BlocksKit.h
@@ -49,14 +49,14 @@
  
  @return The UIAlertView.
  */
-+ (instancetype)bk_showAlertViewWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSArray *)otherButtonTitles handler:(void (^)(UIAlertView *alertView, NSInteger buttonIndex))block BK_ALERT_CONTROLLER_DEPRECATED(2_0);
++ (instancetype)bk_showAlertViewWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSArray *)otherButtonTitles handler:(void (^)(UIAlertView *alertView, NSInteger buttonIndex))block BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Creates and returns a new alert view with only a title and cancel button.
 
  @param title The title of the alert view.
  @return A newly created alert view.
  */
-+ (instancetype)bk_alertViewWithTitle:(NSString *)title BK_ALERT_CONTROLLER_DEPRECATED(2_0);
++ (instancetype)bk_alertViewWithTitle:(NSString *)title BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Creates and returns a new alert view with only a title, message, and cancel button.
 
@@ -64,7 +64,7 @@
  @param message The message content of the alert.
  @return A newly created alert view.
  */
-+ (instancetype)bk_alertViewWithTitle:(NSString *)title message:(NSString *)message BK_ALERT_CONTROLLER_DEPRECATED(2_0);
++ (instancetype)bk_alertViewWithTitle:(NSString *)title message:(NSString *)message BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Returns a configured alert view with only a title, message, and cancel button.
  
@@ -72,7 +72,7 @@
  @param message The message content of the alert.
  @return An instantiated alert view.
  */
-- (instancetype)bk_initWithTitle:(NSString *)title message:(NSString *)message BK_INITIALIZER BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (instancetype)bk_initWithTitle:(NSString *)title message:(NSString *)message BK_DISABLE_FOR_APP_EXTENSION BK_INITIALIZER BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 ///-----------------------------------
 /// @name Adding buttons
@@ -83,14 +83,14 @@
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (NSInteger)bk_addButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** Set the title and trigger of the cancel button.
  
  @param title The text of the button.
  @param block A block of code.
  */
-- (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (NSInteger)bk_setCancelButtonWithTitle:(NSString *)title handler:(void (^)(void))block BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 ///-----------------------------------
 /// @name Altering actions
@@ -101,14 +101,14 @@
  @param block A code block, or nil to set no response.
  @param index The index of a button already added to the action sheet.
  */
-- (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (void)bk_setHandler:(void (^)(void))block forButtonAtIndex:(NSInteger)index BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block that is to be fired when a button is pressed.
  
  @param index The index of the button already added to the alert view.
  @return A code block, or nil if no block yet assigned.
  */
-- (void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+- (void (^)(void))bk_handlerForButtonAtIndex:(NSInteger)index BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired when the action sheet is dismissed with the cancel
  button.
@@ -117,21 +117,21 @@
  property multiple times but multiple cancel buttons will
  not be generated.
  */
-@property (nonatomic, copy, setter = bk_setCancelBlock:) void (^bk_cancelBlock)(void) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setCancelBlock:) void (^bk_cancelBlock)(void) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired before the alert view will show. */
-@property (nonatomic, copy, setter = bk_setWillShowBlock:) void (^bk_willShowBlock)(UIAlertView *alertView) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setWillShowBlock:) void (^bk_willShowBlock)(UIAlertView *alertView) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired when the alert view shows. */
-@property (nonatomic, copy, setter = bk_setDidShowBlock:) void (^bk_didShowBlock)(UIAlertView *alertView) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setDidShowBlock:) void (^bk_didShowBlock)(UIAlertView *alertView) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired before the alert view will dismiss. */
-@property (nonatomic, copy, setter = bk_setWillDismissBlock:) void (^bk_willDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setWillDismissBlock:) void (^bk_willDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired after the alert view dismisses. */
-@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex) BK_ALERT_CONTROLLER_DEPRECATED(2_0);
+@property (nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIAlertView *alertView, NSInteger buttonIndex) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(2_0);
 
 /** The block to be fired to determine whether the first non-cancel should be enabled */
-@property (nonatomic, copy, setter = bk_SetShouldEnableFirstOtherButtonBlock:) BOOL (^bk_shouldEnableFirstOtherButtonBlock)(UIAlertView *alertView) BK_ALERT_CONTROLLER_DEPRECATED(5_0);
+@property (nonatomic, copy, setter = bk_SetShouldEnableFirstOtherButtonBlock:) BOOL (^bk_shouldEnableFirstOtherButtonBlock)(UIAlertView *alertView) BK_DISABLE_FOR_APP_EXTENSION BK_ALERT_CONTROLLER_DEPRECATED(5_0);
 
 @end


### PR DESCRIPTION
I added `NS_EXTENSION_UNAVAILABLE_IOS` attribute for appropriate methods. Now BlocksKit can be used in app extensions without any separate podspecs or so on.