### PR TITLE
Added dynamic delegate for `UIPopoverPresentationController`

### DIFF
--- a/BlocksKit/UIKit/UIPopoverPresentationController+BlocksKit.h
+++ b/BlocksKit/UIKit/UIPopoverPresentationController+BlocksKit.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+
+@interface UIPopoverPresentationController (BlocksKit)
+
+/** The block to be called when the popover controller will dismiss the popover. Return NO to prevent the dismissal of the view. */
+@property (nullable, nonatomic, copy, setter = bk_setShouldDismissBlock:) BOOL (^bk_shouldDismissBlock)(UIPopoverPresentationController * __nonnull popoverPresentationController);
+
+/** The block to be called when the user has taken action to dismiss the popover. This is not called when - dismissModalViewControllerAnimated: is called directly. */
+@property (nullable, nonatomic, copy, setter = bk_setDidDismissBlock:) void (^bk_didDismissBlock)(UIPopoverPresentationController  * __nonnull popoverPresentationController);
+
+/** The block to be called in response to interface changes that require a new size for the popover. */
+@property (nullable, nonatomic, copy, setter = bk_setWillRepositionPopoverToRectInViewBlock:) void (^bk_willRepositionPopoverToRectInViewBlock)(UIPopoverPresentationController  * __nonnull popoverPresentationController, CGRect * __nonnull rect, UIView  * __nonnull * __nonnull view);
+
+@end

--- a/BlocksKit/UIKit/UIPopoverPresentationController+BlocksKit.m
+++ b/BlocksKit/UIKit/UIPopoverPresentationController+BlocksKit.m
@@ -1,0 +1,66 @@
+#import "A2DynamicDelegate.h"
+#import "NSObject+A2BlockDelegate.h"
+#import "UIPopoverPresentationController+BlocksKit.h"
+
+#pragma mark - Delegate
+
+@interface A2DynamicUIPopoverPresentationControllerDelegate : A2DynamicDelegate <UIPopoverPresentationControllerDelegate>
+
+@end
+
+@implementation A2DynamicUIPopoverPresentationControllerDelegate
+
+- (BOOL)popoverControllerShouldDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
+{
+	BOOL should = YES;
+	
+	id realDelegate = self.realDelegate;
+	if (realDelegate && [realDelegate respondsToSelector:@selector(popoverPresentationControllerShouldDismissPopover:)])
+		should &= [realDelegate popoverPresentationControllerShouldDismissPopover:popoverPresentationController];
+	
+	BOOL (^block)(UIPopoverPresentationController *) = [self blockImplementationForMethod:_cmd];
+	if (block) should &= block(popoverPresentationController);
+	
+	return should;
+}
+
+- (void)popoverControllerDidDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
+{
+	id realDelegate = self.realDelegate;
+	if (realDelegate && [realDelegate respondsToSelector:@selector(popoverPresentationControllerDidDismissPopover:)])
+		[realDelegate popoverPresentationControllerDidDismissPopover:popoverPresentationController];
+	
+	void (^block)(UIPopoverPresentationController *) = [self blockImplementationForMethod:_cmd];
+	if (block) block(popoverPresentationController);
+}
+
+- (void)popoverPresentationController:(UIPopoverPresentationController *)popoverPresentationController willRepositionPopoverToRect:(inout CGRect *)rect inView:(inout UIView **)view {
+	
+	id realDelegate = self.realDelegate;
+	if (realDelegate && [realDelegate respondsToSelector:@selector(popoverPresentationController:willRepositionPopoverToRect:inView:)])
+		[realDelegate popoverPresentationController:popoverPresentationController willRepositionPopoverToRect:rect inView:view];
+
+	void (^block)(UIPopoverPresentationController *, CGRect *, UIView **) = [self blockImplementationForMethod:_cmd];
+	if (block) block(popoverPresentationController, rect, view);
+}
+
+@end
+
+#pragma mark - Category
+
+@implementation UIPopoverPresentationController (BlocksKit)
+
+@dynamic bk_didDismissBlock, bk_shouldDismissBlock, bk_willRepositionPopoverToRectInViewBlock;
+
++ (void)load
+{
+	@autoreleasepool {
+		[self bk_registerDynamicDelegate];
+		[self bk_linkDelegateMethods:@{ @"bk_didDismissBlock": @"popoverPresentationControllerDidDismissPopover:",
+		                                @"bk_shouldDismissBlock": @"popoverPresentationControllerShouldDismissPopover:",
+		                                @"bk_willRepositionPopoverToRectInViewBlock" : @"popoverPresentationController:willRepositionPopoverToRect:inView:"
+		}];
+	}
+}
+
+@end


### PR DESCRIPTION
Note:`bk_willRepositionPopoverToRectInViewBlock` does not work yet as expected due to method/block signature differences due to the `inout` parameters in the corresponding delegate method.

I have not yet found a way to resolve this issue. The problem is that at runtime when I set the block the method 
`initWithBlock:methodSignature:`
 throws the exception 
`@"Attempted to create block invocation with incompatible signatures"`. 

I debugged the method 
`isSignature:compatibleWithSignature:`
 and found that for e.g. the `CGRect` parameter the method/block signatures are the following:
`N^{CGRect={CGPoint=dd}{CGSize=dd}}`
`^{CGRect={CGPoint=dd}{CGSize=dd}}`

`N` means `inout`, see [here](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1). The signatures are therefore not "compatible". 

I commented the check to see if my implementation would work as expected and it does so. So the only problem are the mismatching signatures as far as I can see. 

Do you guys have any idea how to resolve this? Is it a bug in the low-level system methods around `NSMethodSignature` which are used to link the protocol methods to the dynamic delegate? I couldn't find any information on how to use `inout` for block signatures unfortunately.

Thanks!
